### PR TITLE
[FEAT] 따봉도치 만들기 - 내용 작성 UI 구현

### DIFF
--- a/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
+++ b/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		FFD306B12B83B36E004B5AEA /* LoadPhotoUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD306B02B83B36E004B5AEA /* LoadPhotoUIView.swift */; };
 		FFD306B32B83BC3D004B5AEA /* MakeDotchiContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD306B22B83BC3D004B5AEA /* MakeDotchiContentViewController.swift */; };
 		FFD306B52B83BE21004B5AEA /* BaseUINavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD306B42B83BE21004B5AEA /* BaseUINavigationController.swift */; };
+		FFD306B82B83C15E004B5AEA /* DotchiUITextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD306B72B83C15E004B5AEA /* DotchiUITextField.swift */; };
+		FFD306BA2B83C25D004B5AEA /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD306B92B83C25D004B5AEA /* UITextField+.swift */; };
 		FFD593FE2B70FCDD003F1F3C /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = FFD593FD2B70FCDD003F1F3C /* CombineMoya */; };
 		FFD594002B70FCDD003F1F3C /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = FFD593FF2B70FCDD003F1F3C /* Moya */; };
 		FFD594022B70FCDD003F1F3C /* ReactiveMoya in Frameworks */ = {isa = PBXBuildFile; productRef = FFD594012B70FCDD003F1F3C /* ReactiveMoya */; };
@@ -135,6 +137,8 @@
 		FFD306B02B83B36E004B5AEA /* LoadPhotoUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadPhotoUIView.swift; sourceTree = "<group>"; };
 		FFD306B22B83BC3D004B5AEA /* MakeDotchiContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeDotchiContentViewController.swift; sourceTree = "<group>"; };
 		FFD306B42B83BE21004B5AEA /* BaseUINavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseUINavigationController.swift; sourceTree = "<group>"; };
+		FFD306B72B83C15E004B5AEA /* DotchiUITextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotchiUITextField.swift; sourceTree = "<group>"; };
+		FFD306B92B83C25D004B5AEA /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		FFD594172B70FF2A003F1F3C /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		FFD5941D2B70FF66003F1F3C /* AuthRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRouter.swift; sourceTree = "<group>"; };
 		FFD5941F2B710135003F1F3C /* BaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseService.swift; sourceTree = "<group>"; };
@@ -309,6 +313,14 @@
 			path = UIViewControllerRepresentable;
 			sourceTree = "<group>";
 		};
+		FFD306B62B83C13C004B5AEA /* TextFields */ = {
+			isa = PBXGroup;
+			children = (
+				FFD306B72B83C15E004B5AEA /* DotchiUITextField.swift */,
+			);
+			path = TextFields;
+			sourceTree = "<group>";
+		};
 		FFD594152B70FF14003F1F3C /* Supports */ = {
 			isa = PBXGroup;
 			children = (
@@ -424,6 +436,7 @@
 		FFD5943B2B710370003F1F3C /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				FFD306B62B83C13C004B5AEA /* TextFields */,
 				FF8322882B7C59350069D68A /* CollectionViewCells */,
 				FF018E9E2B77FA5D006D5627 /* Views */,
 				FF018E7E2B7531F8006D5627 /* Buttons */,
@@ -468,6 +481,7 @@
 				FF8322862B7C58BD0069D68A /* Adjusted+.swift */,
 				FF8322942B7CACE00069D68A /* UIImageView+.swift */,
 				FF8322982B7CD1580069D68A /* UIStackView+.swift */,
+				FFD306B92B83C25D004B5AEA /* UITextField+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -621,12 +635,14 @@
 				FFD594452B7103D8003F1F3C /* UserInfo.swift in Sources */,
 				107D6E5F2B78DB61005B6261 /* FontManager.swift in Sources */,
 				FFD306AD2B8336E9004B5AEA /* DotchiDoneUIButton.swift in Sources */,
+				FFD306BA2B83C25D004B5AEA /* UITextField+.swift in Sources */,
 				FF018E9D2B77F9D7006D5627 /* UIView+.swift in Sources */,
 				FF018EA52B7803CE006D5627 /* UIViewControllerToSwiftUI.swift in Sources */,
 				FFD594312B7101E1003F1F3C /* SocialLoginRequestDTO.swift in Sources */,
 				FFD5942A2B7101A2003F1F3C /* NetworkResult.swift in Sources */,
 				FF8322812B7BD2190069D68A /* DotchiSortUIButton.swift in Sources */,
 				FF018E9B2B77F95F006D5627 /* BrowseViewController.swift in Sources */,
+				FFD306B82B83C15E004B5AEA /* DotchiUITextField.swift in Sources */,
 				FF018E802B75321B006D5627 /* DotchiCircleUIButton.swift in Sources */,
 				FFD594242B710166003F1F3C /* APIConstants.swift in Sources */,
 				FFD594182B70FF2A003F1F3C /* Environment.swift in Sources */,

--- a/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
+++ b/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		FFD306AD2B8336E9004B5AEA /* DotchiDoneUIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD306AC2B8336E9004B5AEA /* DotchiDoneUIButton.swift */; };
 		FFD306AF2B83AC5E004B5AEA /* MakeDotchiEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD306AE2B83AC5E004B5AEA /* MakeDotchiEntity.swift */; };
 		FFD306B12B83B36E004B5AEA /* LoadPhotoUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD306B02B83B36E004B5AEA /* LoadPhotoUIView.swift */; };
+		FFD306B32B83BC3D004B5AEA /* MakeDotchiContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD306B22B83BC3D004B5AEA /* MakeDotchiContentViewController.swift */; };
+		FFD306B52B83BE21004B5AEA /* BaseUINavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD306B42B83BE21004B5AEA /* BaseUINavigationController.swift */; };
 		FFD593FE2B70FCDD003F1F3C /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = FFD593FD2B70FCDD003F1F3C /* CombineMoya */; };
 		FFD594002B70FCDD003F1F3C /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = FFD593FF2B70FCDD003F1F3C /* Moya */; };
 		FFD594022B70FCDD003F1F3C /* ReactiveMoya in Frameworks */ = {isa = PBXBuildFile; productRef = FFD594012B70FCDD003F1F3C /* ReactiveMoya */; };
@@ -131,6 +133,8 @@
 		FFD306AC2B8336E9004B5AEA /* DotchiDoneUIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotchiDoneUIButton.swift; sourceTree = "<group>"; };
 		FFD306AE2B83AC5E004B5AEA /* MakeDotchiEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeDotchiEntity.swift; sourceTree = "<group>"; };
 		FFD306B02B83B36E004B5AEA /* LoadPhotoUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadPhotoUIView.swift; sourceTree = "<group>"; };
+		FFD306B22B83BC3D004B5AEA /* MakeDotchiContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakeDotchiContentViewController.swift; sourceTree = "<group>"; };
+		FFD306B42B83BE21004B5AEA /* BaseUINavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseUINavigationController.swift; sourceTree = "<group>"; };
 		FFD594172B70FF2A003F1F3C /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
 		FFD5941D2B70FF66003F1F3C /* AuthRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRouter.swift; sourceTree = "<group>"; };
 		FFD5941F2B710135003F1F3C /* BaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseService.swift; sourceTree = "<group>"; };
@@ -292,6 +296,7 @@
 			isa = PBXGroup;
 			children = (
 				FFD306A12B809960004B5AEA /* MakeDotchiPhotoViewController.swift */,
+				FFD306B22B83BC3D004B5AEA /* MakeDotchiContentViewController.swift */,
 			);
 			path = Make;
 			sourceTree = "<group>";
@@ -445,6 +450,7 @@
 			isa = PBXGroup;
 			children = (
 				FFD594482B710411003F1F3C /* BaseViewController.swift */,
+				FFD306B42B83BE21004B5AEA /* BaseUINavigationController.swift */,
 			);
 			path = Bases;
 			sourceTree = "<group>";
@@ -600,9 +606,11 @@
 				100A1E2E2B71576B00AAC1E8 /* UploadView.swift in Sources */,
 				FFD306A22B809960004B5AEA /* MakeDotchiPhotoViewController.swift in Sources */,
 				FF83228A2B7C59540069D68A /* BrowseUICollectionViewCell.swift in Sources */,
+				FFD306B32B83BC3D004B5AEA /* MakeDotchiContentViewController.swift in Sources */,
 				FFD594332B710218003F1F3C /* NetworkLoggerPlugin.swift in Sources */,
 				FF83228C2B7C5AE00069D68A /* CardFrontUIView.swift in Sources */,
 				FFAA7D352B70F36600C7620E /* ContentView.swift in Sources */,
+				FFD306B52B83BE21004B5AEA /* BaseUINavigationController.swift in Sources */,
 				FF8322992B7CD1580069D68A /* UIStackView+.swift in Sources */,
 				FF83227F2B7BCAC80069D68A /* UILabel+.swift in Sources */,
 				FFD594472B7103EF003F1F3C /* ImageCacheManager.swift in Sources */,

--- a/DOTCHI/DOTCHI/Global/Bases/BaseUINavigationController.swift
+++ b/DOTCHI/DOTCHI/Global/Bases/BaseUINavigationController.swift
@@ -1,0 +1,46 @@
+//
+//  BaseUINavigationController.swift
+//  DOTCHI
+//
+//  Created by Jungbin on 2/20/24.
+//
+
+import UIKit
+
+final class BaseUINavigationController: UINavigationController {
+    
+    // MARK: Initializer
+    
+    override init(rootViewController: UIViewController) {
+        super.init(rootViewController: rootViewController)
+        
+        self.modalPresentationStyle = .fullScreen
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: View Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.interactivePopGestureRecognizer?.delegate = self
+        self.hideNavigationBar()
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension BaseUINavigationController: UIGestureRecognizerDelegate {
+    
+    /// NavigationBar를 안 쓰고 UIView로 네비바를 구현할 때, 스와이프로 뒤로 가기 가능하게 함
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return self.viewControllers.count > 1
+    }
+    
+    func hideNavigationBar() {
+        self.navigationBar.isHidden = true
+    }
+}

--- a/DOTCHI/DOTCHI/Global/Bases/BaseViewController.swift
+++ b/DOTCHI/DOTCHI/Global/Bases/BaseViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import SnapKit
 
-class BaseViewController: UIViewController {
+class BaseViewController: UIViewController, UIGestureRecognizerDelegate {
     
     // MARK: UIComponents
     
@@ -16,7 +16,8 @@ class BaseViewController: UIViewController {
     
     // MARK: Properties
     
-    
+    let screenWidth = UIScreen.main.bounds.size.width
+    let screenHeight = UIScreen.main.bounds.size.height
     
     // MARK: View Life Cycle
     
@@ -24,6 +25,7 @@ class BaseViewController: UIViewController {
         super.viewDidLoad()
         
         self.setBackgroundColor()
+        self.hideKeyboardWhenTappedAround()
     }
     
     // MARK: Methods
@@ -40,5 +42,13 @@ class BaseViewController: UIViewController {
         button.setAction { [weak self] in
             self?.navigationController?.popViewController(animated: true)
         }
+    }
+    
+    /// 화면 터치 시 키보드 내리는 메서드
+    func hideKeyboardWhenTappedAround() {
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(UIViewController.dismissKeyboard))
+        tap.delegate = self
+        tap.cancelsTouchesInView = false
+        self.view.addGestureRecognizer(tap)
     }
 }

--- a/DOTCHI/DOTCHI/Global/Extensions/UITextField+.swift
+++ b/DOTCHI/DOTCHI/Global/Extensions/UITextField+.swift
@@ -1,0 +1,47 @@
+//
+//  UITextField+.swift
+//  DOTCHI
+//
+//  Created by Jungbin on 2/20/24.
+//
+
+import UIKit
+
+extension UITextField {
+    
+    /// UITextField 왼쪽에 여백 주는 메서드
+    func addLeftPadding(_ amount: CGFloat) {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: amount, height: self.frame.size.height))
+        self.leftView = paddingView
+        self.leftViewMode = .always
+    }
+    
+    /// UITextField 오른쪽에 여백 주는 메서드
+    func addRightPadding(_ amount: CGFloat) {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: amount, height: self.frame.size.height))
+        self.rightView = paddingView
+        self.rightViewMode = .always
+    }
+    
+    /// 자간 설정 메서드
+    func setCharacterSpacing(_ spacing: CGFloat){
+        let attributedStr = NSMutableAttributedString(string: self.text ?? "")
+        attributedStr.addAttribute(NSAttributedString.Key.kern, value: spacing, range: NSMakeRange(0, attributedStr.length))
+        self.attributedText = attributedStr
+    }
+    
+    func clearSideEmptyText() -> String? {
+        if let text = self.text {
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            return nil
+        }
+    }
+    
+    func setDotchiPlaceholder(_ text: String) {
+        self.attributedPlaceholder = NSAttributedString(
+            string: text,
+            attributes: [NSAttributedString.Key.foregroundColor: UIColor.dotchiWhite.withAlphaComponent(0.3)]
+        )
+    }
+}

--- a/DOTCHI/DOTCHI/Global/UIViewControllerRepresentable/MakeDotchiPhotoViewControllerRepresentable.swift
+++ b/DOTCHI/DOTCHI/Global/UIViewControllerRepresentable/MakeDotchiPhotoViewControllerRepresentable.swift
@@ -13,9 +13,9 @@ struct MakeDotchiPhotoViewControllerRepresentable: UIViewControllerRepresentable
     @Binding var isPresented: Bool
     
     func makeUIViewController(context: Context) -> UIViewController {
-        let makeDotchiPhotoViewController = MakeDotchiPhotoViewController()
+        let makeDotchiPhotoViewController = BaseUINavigationController(rootViewController: MakeDotchiPhotoViewController())
         
-        makeDotchiPhotoViewController.delegate = context.coordinator
+        makeDotchiPhotoViewController.delegate = context.coordinator as? any UINavigationControllerDelegate
         return makeDotchiPhotoViewController
     }
     

--- a/DOTCHI/DOTCHI/Sources/Components/TextFields/DotchiUITextField.swift
+++ b/DOTCHI/DOTCHI/Sources/Components/TextFields/DotchiUITextField.swift
@@ -1,0 +1,37 @@
+//
+//  DotchiUITextField.swift
+//  DOTCHI
+//
+//  Created by Jungbin on 2/20/24.
+//
+
+import UIKit
+import SnapKit
+
+final class DotchiUITextField: UITextField {
+    
+    // MARK: Properties
+    
+    // MARK: Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        self.setUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: Methods
+    
+    private func setUI() {
+        self.backgroundColor = .dotchiMgray
+        self.font = .head2
+        self.textColor = .dotchiWhite
+        self.addLeftPadding(12)
+        self.addRightPadding(12)
+        self.makeRounded(cornerRadius: 8)
+    }
+}

--- a/DOTCHI/DOTCHI/Sources/Components/Views/DotchiNavigationUIView.swift
+++ b/DOTCHI/DOTCHI/Sources/Components/Views/DotchiNavigationUIView.swift
@@ -12,6 +12,7 @@ final class DotchiNavigationUIView: UIView {
     enum NavigationType {
         case back
         case closeCenterTitle
+        case backCenterTitle
     }
     
     // MARK: UIComponents
@@ -45,6 +46,7 @@ final class DotchiNavigationUIView: UIView {
         switch type {
         case .back: self.setBackLayout()
         case .closeCenterTitle: self.setCloseCenterTitleLayout()
+        case .backCenterTitle: self.setBackCenterTitleLayout()
         }
     }
     
@@ -72,6 +74,13 @@ extension DotchiNavigationUIView {
         self.addSubviews([closeButton, centerTitleLabel])
         
         self.setLeftButtonLayout(button: self.closeButton)
+        self.setCenterTitleLabelLayout()
+    }
+    
+    private func setBackCenterTitleLayout() {
+        self.addSubviews([backButton, centerTitleLabel])
+        
+        self.setLeftButtonLayout(button: self.backButton)
         self.setCenterTitleLabelLayout()
     }
     

--- a/DOTCHI/DOTCHI/Sources/Entities/MakeDotchiEntity.swift
+++ b/DOTCHI/DOTCHI/Sources/Entities/MakeDotchiEntity.swift
@@ -16,7 +16,7 @@ struct MakeDotchiEntity {
     
     init() {
         self.image = UIImage()
-        self.luckyType = .lucky
+        self.luckyType = .health
         self.dotchiName = ""
         self.dotchiMood = ""
         self.dotchiContent = ""

--- a/DOTCHI/DOTCHI/Sources/Screens/Make/MakeDotchiContentViewController.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Make/MakeDotchiContentViewController.swift
@@ -13,14 +13,100 @@ final class MakeDotchiContentViewController: BaseViewController {
     private enum Text {
         static let title = "따봉도치 만들기"
         static let next = "다음"
+        static let dotchiNameInfo = "따봉네임 (7자)"
+        static let dotchiNameGuide = "나는"
+        static let dotchiNamePlaceholder = "Ex) 따봉도치"
+        static let dotchiMoodInfo = "따봉도치의 컨디션 (15자)"
+        static let dotchiMoodGuide = "나는 오늘 좀"
+        static let dotchiMoodPlaceholder = "Ex) 엄지가 절로 올라가"
+        static let dotchiContentInfo = "자유롭게 따봉도치 디테일을 적어 보세요 (20자)"
+        static let dotchiContentPlaceholder = "Ex) 넌 지금 따봉도치와 눈이 마주쳤어!"
+        static let luckyDescriptionHead = "나를 만난 너에게 "
+        static let luckyDescriptionTrail = "을 나눠 줄게!"
     }
     
     // MARK: UIComponents
     
     private let navigationView: DotchiNavigationUIView = {
-        let view: DotchiNavigationUIView = DotchiNavigationUIView(type: .back)
+        let view: DotchiNavigationUIView = DotchiNavigationUIView(type: .backCenterTitle)
         view.centerTitleLabel.text = Text.title
         return view
+    }()
+    
+    private let scrollView: UIScrollView = UIScrollView()
+    private let contentView: UIView = UIView()
+    
+    private let dotchiNameInfoLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.setStyle(.sub, .dotchiWhite.withAlphaComponent(0.5))
+        label.text = Text.dotchiNameInfo
+        return label
+    }()
+    
+    private let dotchiNameGuideLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.setStyle(.body, .dotchiWhite)
+        label.text = Text.dotchiNameGuide
+        return label
+    }()
+    
+    private let dotchiNameTextField: DotchiUITextField = {
+        let textField: DotchiUITextField = DotchiUITextField()
+        textField.setDotchiPlaceholder(Text.dotchiNamePlaceholder)
+        return textField
+    }()
+    
+    private let dotchiMoodInfoLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.setStyle(.sub, .dotchiWhite.withAlphaComponent(0.5))
+        label.text = Text.dotchiMoodInfo
+        return label
+    }()
+    
+    private let dotchiMoodGuideLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.setStyle(.body, .dotchiWhite)
+        label.text = Text.dotchiMoodGuide
+        return label
+    }()
+    
+    private let dotchiMoodTextField: DotchiUITextField = {
+        let textField: DotchiUITextField = DotchiUITextField()
+        textField.setDotchiPlaceholder(Text.dotchiMoodPlaceholder)
+        return textField
+    }()
+    
+    private let dotchiContentInfoLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.setStyle(.sub, .dotchiWhite.withAlphaComponent(0.5))
+        label.text = Text.dotchiContentInfo
+        return label
+    }()
+    
+    private let dotchiContentTextView: UITextView = {
+        let textView: UITextView = UITextView()
+        textView.backgroundColor = .dotchiMgray
+        textView.font = .head2
+        textView.textColor = .dotchiWhite.withAlphaComponent(0.3)
+        textView.text = Text.dotchiContentPlaceholder
+        textView.textContainerInset = .init(top: 12, left: 12, bottom: 12, right: 12)
+        textView.contentInset = .zero
+        textView.textContainer.lineFragmentPadding = .zero
+        textView.makeRounded(cornerRadius: 8)
+        return textView
+    }()
+    
+    private let luckyDescriptionLabel: UILabel = {
+        let label: UILabel = UILabel()
+        label.setStyle(.body, .dotchiWhite)
+        return label
+    }()
+    
+    private let nextButton: DotchiDoneUIButton = {
+        let button: DotchiDoneUIButton = DotchiDoneUIButton()
+        button.setTitle(Text.next, for: .normal)
+        button.isEnabled = false
+        return button
     }()
     
     // MARK: Properties
@@ -45,21 +131,103 @@ final class MakeDotchiContentViewController: BaseViewController {
         super.viewDidLoad()
         
         self.setLayout()
+        self.setBackButtonAction(self.navigationView.backButton)
+        self.setLuckyDescriptionLabel()
     }
     
     // MARK: Methods
     
-    
+    private func setLuckyDescriptionLabel() {
+        self.luckyDescriptionLabel.text = Text.luckyDescriptionHead + self.makeDotchiData.luckyType.name() + Text.luckyDescriptionTrail
+        self.luckyDescriptionLabel.setColor(to: self.makeDotchiData.luckyType.name(), with: self.makeDotchiData.luckyType.uiColorNormal())
+    }
 }
 
 // MARK: - Layout
 
 extension MakeDotchiContentViewController {
     private func setLayout() {
-        self.view.addSubviews([navigationView])
+        self.view.addSubviews([navigationView, scrollView, nextButton])
+        self.scrollView.addSubviews([contentView])
+        self.contentView.addSubviews([
+            dotchiNameInfoLabel, dotchiNameGuideLabel, dotchiNameTextField,
+            dotchiMoodInfoLabel, dotchiMoodGuideLabel, dotchiMoodTextField,
+            dotchiContentInfoLabel, dotchiContentTextView,
+            luckyDescriptionLabel
+        ])
         
         self.navigationView.snp.makeConstraints { make in
             make.top.horizontalEdges.equalTo(self.view.safeAreaLayoutGuide)
+        }
+        
+        self.scrollView.snp.makeConstraints { make in
+            make.top.equalTo(self.navigationView.snp.bottom)
+            make.horizontalEdges.bottom.equalToSuperview()
+        }
+        
+        self.contentView.snp.makeConstraints { make in
+            make.edges.width.equalToSuperview()
+        }
+        
+        self.dotchiNameInfoLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(32)
+            make.horizontalEdges.equalToSuperview().inset(28)
+            make.height.equalTo(14)
+        }
+        
+        self.dotchiNameGuideLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.dotchiNameInfoLabel.snp.bottom).offset(16)
+            make.horizontalEdges.equalToSuperview().inset(28)
+            make.height.equalTo(22)
+        }
+        
+        self.dotchiNameTextField.snp.makeConstraints { make in
+            make.top.equalTo(self.dotchiNameGuideLabel.snp.bottom).offset(14)
+            make.horizontalEdges.equalToSuperview().inset(28)
+            make.height.equalTo(40)
+        }
+        
+        self.dotchiMoodInfoLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.dotchiNameTextField.snp.bottom).offset(40)
+            make.horizontalEdges.equalToSuperview().inset(28)
+            make.height.equalTo(14)
+        }
+        
+        self.dotchiMoodGuideLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.dotchiMoodInfoLabel.snp.bottom).offset(16)
+            make.horizontalEdges.equalToSuperview().inset(28)
+            make.height.equalTo(22)
+        }
+        
+        self.dotchiMoodTextField.snp.makeConstraints { make in
+            make.top.equalTo(self.dotchiMoodGuideLabel.snp.bottom).offset(14)
+            make.horizontalEdges.equalToSuperview().inset(28)
+            make.height.equalTo(40)
+        }
+        
+        self.dotchiContentInfoLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.dotchiMoodTextField.snp.bottom).offset(40)
+            make.horizontalEdges.equalToSuperview().inset(28)
+            make.height.equalTo(14)
+        }
+        
+        self.dotchiContentTextView.snp.makeConstraints { make in
+            make.top.equalTo(self.dotchiContentInfoLabel.snp.bottom).offset(16)
+            make.horizontalEdges.equalToSuperview().inset(28)
+            make.height.equalTo(104)
+        }
+        
+        self.luckyDescriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.dotchiContentTextView.snp.bottom).offset(40)
+            make.horizontalEdges.equalToSuperview().inset(28)
+            make.height.equalTo(22)
+            make.bottom.equalToSuperview().inset(32)
+        }
+        
+        self.nextButton.snp.makeConstraints { make in
+            make.horizontalEdges.equalToSuperview().inset(28)
+            make.height.equalTo(52)
+            make.bottom.equalToSuperview().inset(32)
         }
     }
 }

--- a/DOTCHI/DOTCHI/Sources/Screens/Make/MakeDotchiContentViewController.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Make/MakeDotchiContentViewController.swift
@@ -1,0 +1,65 @@
+//
+//  MakeDotchiContentViewController.swift
+//  DOTCHI
+//
+//  Created by Jungbin on 2/20/24.
+//
+
+import UIKit
+import SnapKit
+
+final class MakeDotchiContentViewController: BaseViewController {
+    
+    private enum Text {
+        static let title = "따봉도치 만들기"
+        static let next = "다음"
+    }
+    
+    // MARK: UIComponents
+    
+    private let navigationView: DotchiNavigationUIView = {
+        let view: DotchiNavigationUIView = DotchiNavigationUIView(type: .back)
+        view.centerTitleLabel.text = Text.title
+        return view
+    }()
+    
+    // MARK: Properties
+    
+    private var makeDotchiData: MakeDotchiEntity = MakeDotchiEntity()
+    
+    // MARK: Initializer
+    
+    init(makeDotchiData: MakeDotchiEntity) {
+        super.init(nibName: nil, bundle: nil)
+        
+        self.makeDotchiData = makeDotchiData
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: View Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.setLayout()
+    }
+    
+    // MARK: Methods
+    
+    
+}
+
+// MARK: - Layout
+
+extension MakeDotchiContentViewController {
+    private func setLayout() {
+        self.view.addSubviews([navigationView])
+        
+        self.navigationView.snp.makeConstraints { make in
+            make.top.horizontalEdges.equalTo(self.view.safeAreaLayoutGuide)
+        }
+    }
+}

--- a/DOTCHI/DOTCHI/Sources/Screens/Make/MakeDotchiPhotoViewController.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Make/MakeDotchiPhotoViewController.swift
@@ -84,6 +84,7 @@ final class MakeDotchiPhotoViewController: BaseViewController {
         self.setCollectionViewLayout()
         self.setCollectionView()
         self.setImagePickerController()
+        self.setNextButtonAction()
     }
     
     // MARK: Methods
@@ -121,6 +122,15 @@ final class MakeDotchiPhotoViewController: BaseViewController {
     
     private func setImagePickerController() {
         self.imagePickerController.delegate = self
+    }
+    
+    private func setNextButtonAction() {
+        self.nextButton.setAction { [weak self] in
+            self?.navigationController?.pushViewController(
+                MakeDotchiContentViewController(makeDotchiData: self?.makeDotchiData ?? .init()),
+                animated: true
+            )
+        }
     }
 }
 

--- a/DOTCHI/DOTCHI/Sources/Screens/Make/MakeDotchiPhotoViewController.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Make/MakeDotchiPhotoViewController.swift
@@ -174,6 +174,7 @@ extension MakeDotchiPhotoViewController: UICollectionViewDelegateFlowLayout {
         
         let indexPath = IndexPath(item: Int(roundedIndex), section: 0)
         self.currentCellIndex = Int(roundedIndex)
+        self.makeDotchiData.luckyType = LuckyType(rawValue: self.currentCellIndex + 1) ?? .health
         
         if let cell = self.collectionView.cellForItem(at: indexPath) {
             self.zoomFocusCell(cell: cell, isFocus: true)


### PR DESCRIPTION
## 작업한 내용
- BaseUINavigationController 구현 (화면 전환 위해)
- 사진 선택 -> 내용 작성으로 넘어갈 때 데이터 전달 구현
- DotchiUITextField 컴포넌트 구현
- 따봉도치 만들기 - 내용 작성 UI 구현

## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- #41 브랜치에서 이어서 작업해서 커밋이 쌓였습니다..ㅎ
- 글자수 제한 등 서비스로직은 다음 이슈에서 작업할게요~!

## 📸 스크린샷
![image](https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/43312096/59033a7a-62a9-4cad-a252-42c2da186c3a)


## 관련 이슈
- Resolved: #31
