### PR TITLE
[FEAT] 홈 API 연동

### DIFF
--- a/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
+++ b/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		10FD9EB42B87A3AD00288506 /* HomeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EB32B87A3AD00288506 /* HomeRouter.swift */; };
 		10FD9EB82B87A50900288506 /* HomeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EB72B87A50900288506 /* HomeResponseDTO.swift */; };
 		10FD9EBA2B87A59400288506 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EB92B87A59400288506 /* HomeService.swift */; };
+		10FD9EBC2B8868B300288506 /* AsyncImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EBB2B8868B300288506 /* AsyncImageView.swift */; };
 		FF018E802B75321B006D5627 /* DotchiCircleUIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E7F2B75321B006D5627 /* DotchiCircleUIButton.swift */; };
 		FF018E942B77F2E6006D5627 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E932B77F2E6006D5627 /* UIFont+.swift */; };
 		FF018E9B2B77F95F006D5627 /* BrowseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E9A2B77F95F006D5627 /* BrowseViewController.swift */; };
@@ -135,6 +136,7 @@
 		10FD9EB32B87A3AD00288506 /* HomeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRouter.swift; sourceTree = "<group>"; };
 		10FD9EB72B87A50900288506 /* HomeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeResponseDTO.swift; sourceTree = "<group>"; };
 		10FD9EB92B87A59400288506 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
+		10FD9EBB2B8868B300288506 /* AsyncImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImageView.swift; sourceTree = "<group>"; };
 		FF018E7F2B75321B006D5627 /* DotchiCircleUIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotchiCircleUIButton.swift; sourceTree = "<group>"; };
 		FF018E922B77F243006D5627 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		FF018E932B77F2E6006D5627 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
@@ -564,6 +566,7 @@
 				FFD594392B710367003F1F3C /* HomeView.swift */,
 				100182F22B7AAA440024813A /* CollectionView.swift */,
 				10BC6B532B869432007D1D9A /* LottieView.swift */,
+				10FD9EBB2B8868B300288506 /* AsyncImageView.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -821,6 +824,7 @@
 				100A1E2C2B7151C400AAC1E8 /* MyView.swift in Sources */,
 				FF8322852B7C58A60069D68A /* UICollectionView+.swift in Sources */,
 				FF0CF0972B86616700B9DFC1 /* SignInViewControllerRepresentable.swift in Sources */,
+				10FD9EBC2B8868B300288506 /* AsyncImageView.swift in Sources */,
 				FF4F9C082B83DD2600E3DE31 /* String+.swift in Sources */,
 				FF0CF0A12B866F3600B9DFC1 /* Message.swift in Sources */,
 				FFD306B12B83B36E004B5AEA /* LoadPhotoUIView.swift in Sources */,

--- a/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
+++ b/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		10BC6B562B86946F007D1D9A /* pung.json in Resources */ = {isa = PBXBuildFile; fileRef = 10BC6B552B86946F007D1D9A /* pung.json */; };
 		10BC6B582B869514007D1D9A /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 10BC6B572B869514007D1D9A /* Lottie */; };
 		10BC6B5A2B86ABA0007D1D9A /* ProfileEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10BC6B592B86ABA0007D1D9A /* ProfileEditView.swift */; };
+		10FD9EB42B87A3AD00288506 /* HomeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EB32B87A3AD00288506 /* HomeRouter.swift */; };
+		10FD9EB82B87A50900288506 /* HomeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EB72B87A50900288506 /* HomeResponseDTO.swift */; };
+		10FD9EBA2B87A59400288506 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EB92B87A59400288506 /* HomeService.swift */; };
 		FF018E802B75321B006D5627 /* DotchiCircleUIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E7F2B75321B006D5627 /* DotchiCircleUIButton.swift */; };
 		FF018E942B77F2E6006D5627 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E932B77F2E6006D5627 /* UIFont+.swift */; };
 		FF018E9B2B77F95F006D5627 /* BrowseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E9A2B77F95F006D5627 /* BrowseViewController.swift */; };
@@ -129,6 +132,9 @@
 		10BC6B532B869432007D1D9A /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
 		10BC6B552B86946F007D1D9A /* pung.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = pung.json; sourceTree = "<group>"; };
 		10BC6B592B86ABA0007D1D9A /* ProfileEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditView.swift; sourceTree = "<group>"; };
+		10FD9EB32B87A3AD00288506 /* HomeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRouter.swift; sourceTree = "<group>"; };
+		10FD9EB72B87A50900288506 /* HomeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeResponseDTO.swift; sourceTree = "<group>"; };
+		10FD9EB92B87A59400288506 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
 		FF018E7F2B75321B006D5627 /* DotchiCircleUIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotchiCircleUIButton.swift; sourceTree = "<group>"; };
 		FF018E922B77F243006D5627 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		FF018E932B77F2E6006D5627 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
@@ -232,6 +238,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		10FD9EB52B87A4D900288506 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				10FD9EB62B87A4F000288506 /* Response */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		10FD9EB62B87A4F000288506 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				10FD9EB72B87A50900288506 /* HomeResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
 		FF018E7E2B7531F8006D5627 /* Buttons */ = {
 			isa = PBXGroup;
 			children = (
@@ -445,6 +467,7 @@
 		FFD594192B70FF47003F1F3C /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				10FD9EB52B87A4D900288506 /* Home */,
 				FF0CF0A62B8707E200B9DFC1 /* Card */,
 				FFD5942B2B7101B0003F1F3C /* Auth */,
 			);
@@ -468,6 +491,7 @@
 				FFD5941F2B710135003F1F3C /* BaseService.swift */,
 				FFD594212B710147003F1F3C /* AuthService.swift */,
 				FF0CF0AC2B870D4000B9DFC1 /* CardService.swift */,
+				10FD9EB92B87A59400288506 /* HomeService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -477,6 +501,7 @@
 			children = (
 				FFD5941D2B70FF66003F1F3C /* AuthRouter.swift */,
 				FF0CF0A42B87076F00B9DFC1 /* CardRouter.swift */,
+				10FD9EB32B87A3AD00288506 /* HomeRouter.swift */,
 			);
 			path = Routers;
 			sourceTree = "<group>";
@@ -780,6 +805,7 @@
 				FF4F9C112B860A8C00E3DE31 /* UITableView+.swift in Sources */,
 				FFD594242B710166003F1F3C /* APIConstants.swift in Sources */,
 				FFD594182B70FF2A003F1F3C /* Environment.swift in Sources */,
+				10FD9EB82B87A50900288506 /* HomeResponseDTO.swift in Sources */,
 				FFD5941E2B70FF66003F1F3C /* AuthRouter.swift in Sources */,
 				FFD306A92B80B51A004B5AEA /* MakeDotchiUICollectionViewCell.swift in Sources */,
 				FF8322952B7CACE00069D68A /* UIImageView+.swift in Sources */,
@@ -803,8 +829,10 @@
 				FF8322872B7C58BD0069D68A /* Adjusted+.swift in Sources */,
 				FF0CF0AF2B871C2000B9DFC1 /* UserDefaultsManager.swift in Sources */,
 				FF0CF0A32B8671AA00B9DFC1 /* KeychainKeys.swift in Sources */,
+				10FD9EBA2B87A59400288506 /* HomeService.swift in Sources */,
 				FFD306AF2B83AC5E004B5AEA /* MakeDotchiEntity.swift in Sources */,
 				FF018E942B77F2E6006D5627 /* UIFont+.swift in Sources */,
+				10FD9EB42B87A3AD00288506 /* HomeRouter.swift in Sources */,
 				FF8322972B7CCBC80069D68A /* CardFrontEntity.swift in Sources */,
 				FF8322902B7CA1FC0069D68A /* CardHeadType.swift in Sources */,
 				FFD594282B710183003F1F3C /* DotchiMoyaProvider.swift in Sources */,

--- a/DOTCHI/DOTCHI/Networks/DTO/Home/Response/HomeResponseDTO.swift
+++ b/DOTCHI/DOTCHI/Networks/DTO/Home/Response/HomeResponseDTO.swift
@@ -1,0 +1,40 @@
+//
+//  HomeResponseDTO.swift
+//  DOTCHI
+//
+//  Created by yubin on 2/23/24.
+//
+
+import Foundation
+
+struct HomeResponseDTO: Codable {
+    let code: Int
+    let message: String
+    let result: HomeResultDTO
+}
+
+struct HomeResultDTO: Codable {
+    let todayCards: [TodayCardDTO]?
+    let recentCards: [RecentCardDTO]?
+    let themes: [HomeThemeDTO]?
+}
+
+struct TodayCardDTO: Codable {
+    let cardId: Int
+    let cardImageUrl: String
+    let backName: String
+}
+
+struct RecentCardDTO: Codable {
+    let cardId: Int
+    let memberId: Int
+    let memberName: String
+    let cardImageUrl: String
+    let themeId: Int
+    let backName: String
+}
+
+struct HomeThemeDTO: Codable {
+    let themeId: Int
+    let lastCardCreateAt: String
+}

--- a/DOTCHI/DOTCHI/Networks/Routers/HomeRouter.swift
+++ b/DOTCHI/DOTCHI/Networks/Routers/HomeRouter.swift
@@ -1,0 +1,51 @@
+//
+//  HomeRouter.swift
+//  DOTCHI
+//
+//  Created by yubin on 2/23/24.
+//
+
+import Foundation
+import Moya
+
+enum HomeRouter {
+    case getMain
+}
+
+extension HomeRouter: TargetType {
+
+    var baseURL: URL {
+        return URL(string: APIConstants.baseURL)!
+    }
+
+    var path: String {
+        switch self {
+        case .getMain:
+            return "cards/main"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .getMain:
+            return .get
+        }
+    }
+
+    var task: Task {
+        switch self {
+        case .getMain:
+            return .requestPlain
+        }
+    }
+
+    var headers: [String: String]? {
+        switch self {
+        case .getMain:
+            return [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(UserInfo.shared.accessToken)",
+            ]
+        }
+    }
+}

--- a/DOTCHI/DOTCHI/Networks/Services/HomeService.swift
+++ b/DOTCHI/DOTCHI/Networks/Services/HomeService.swift
@@ -9,7 +9,7 @@ import Foundation
 import Moya
 
 class HomeViewModel: ObservableObject {
-    @Published var homeResult: HomeResultDTO?
+    @Published var homeResult: HomeResponseDTO?
     
     private let provider = DotchiMoyaProvider<HomeRouter>(isLoggingOn: true)
     
@@ -18,14 +18,17 @@ class HomeViewModel: ObservableObject {
             switch result {
             case let .success(response):
                 do {
-                    let MainResponse = try response.map(HomeResultDTO.self)
-                    self.homeResult = MainResponse
+                    let mainResponse = try response.map(HomeResponseDTO.self)
+                    print("Decoded response: \(mainResponse)")
+                    self.homeResult = mainResponse
                 } catch {
                     print("Error parsing response: \(error)")
+                    self.homeResult = nil
                 }
                 
             case let .failure(error):
                 print("Network request failed: \(error)")
+                self.homeResult = nil
             }
         }
     }

--- a/DOTCHI/DOTCHI/Networks/Services/HomeService.swift
+++ b/DOTCHI/DOTCHI/Networks/Services/HomeService.swift
@@ -1,0 +1,64 @@
+//
+//  HomeService.swift
+//  DOTCHI
+//
+//  Created by yubin on 2/23/24.
+//
+
+import Foundation
+import Moya
+
+class HomeViewModel: ObservableObject {
+    @Published var homeResult: HomeResultDTO?
+    
+    private let provider = DotchiMoyaProvider<HomeRouter>(isLoggingOn: true)
+    
+    func fetchHome() {
+        provider.request(.getMain) { result in
+            switch result {
+            case let .success(response):
+                do {
+                    let MainResponse = try response.map(HomeResultDTO.self)
+                    self.homeResult = MainResponse
+                } catch {
+                    print("Error parsing response: \(error)")
+                }
+                
+            case let .failure(error):
+                print("Network request failed: \(error)")
+            }
+        }
+    }
+}
+
+/*
+internal protocol HomeServiceProtocol {
+    func getMain(completion: @escaping (NetworkResult<Any>) -> (Void))
+}
+
+final class HomeService: BaseService {
+    static let shared = HomeService()
+    private lazy var provider = DotchiMoyaProvider<HomeRouter>(isLoggingOn: true)
+    
+    private override init() {}
+}
+
+extension HomeService: HomeServiceProtocol {
+    
+    // [GET] 메인 페이지 조회
+    
+    func getMain(completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        self.provider.request(.getMain) { result in
+            switch result {
+            case .success(let response):
+                let statusCode = response.statusCode
+                let data = response.data
+                let networkResult = self.judgeStatus(by: statusCode, data, String.self)
+                completion(networkResult)
+            case .failure(let error):
+                debugPrint(error)
+            }
+        }
+    }
+}
+*/

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/AsyncImageView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/AsyncImageView.swift
@@ -1,0 +1,48 @@
+//
+//  AsyncImageView.swift
+//  DOTCHI
+//
+//  Created by yubin on 2/23/24.
+//
+
+import SwiftUI
+import Combine
+
+class ImageLoader: ObservableObject {
+    @Published var image: UIImage?
+    private var cancellable: AnyCancellable?
+
+    func load(fromURL url: URL) {
+        cancellable = URLSession.shared.dataTaskPublisher(for: url)
+            .map { UIImage(data: $0.data) }
+            .replaceError(with: nil)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.image = $0 }
+    }
+
+    deinit {
+        cancellable?.cancel()
+    }
+}
+
+struct AsyncImageView: View {
+    @StateObject private var loader = ImageLoader()
+    let url: URL?
+
+    var body: some View {
+        Group {
+            if let image = loader.image {
+                Image(uiImage: image)
+                    .resizable()
+            } else {
+                Image(.imgTest)
+                    .resizable()
+            }
+        }
+        .onAppear {
+            if let url = url {
+                loader.load(fromURL: url)
+            }
+        }
+    }
+}

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/AsyncImageView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/AsyncImageView.swift
@@ -34,9 +34,11 @@ struct AsyncImageView: View {
             if let image = loader.image {
                 Image(uiImage: image)
                     .resizable()
+                    .scaledToFill()
             } else {
                 Image(.imgTest)
                     .resizable()
+                    .scaledToFill()
             }
         }
         .onAppear {

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
@@ -186,41 +186,19 @@ struct HomeView: View {
                     
                     ScrollView(.horizontal) {
                         HStack(alignment: .center, spacing: 12) {
-                            ForEach(1...3, id: \.self) { Index in
+                            ForEach(homeViewModel.homeResult?.result.recentCards ?? [], id: \.cardId) { card in
                                 ZStack(alignment: .bottom) {
                                     ZStack(alignment: .top) {
-                                        Image(.imgDefaultDummy)
-                                            .resizable()
+                                        AsyncImageView(url: URL(string: card.cardImageUrl ?? ""))
                                             .frame(width: 143, height: 211)
                                             .cornerRadius(8.46)
-                                        
+
                                         Image(.imgLuckyFront)
                                             .resizable()
                                             .frame(width: 143, height: 211)
-                                        
-                                        ZStack {
-                                            RoundedRectangle(cornerRadius: 60.25)
-                                                .fill(Color.dotchiDeepGreen)
-                                                .frame(width: 51, height: 20)
-                                            
-                                            HStack(spacing: 0) {
-                                                Image(.imgDefaultDummy)
-                                                    .resizable()
-                                                    .scaledToFill()
-                                                    .frame(width: 14, height: 14)
-                                                    .clipShape(Circle())
-                                                
-                                                Text("오뜨")
-                                                    .font(.S_Sub)
-                                                    .foregroundStyle(Color.dotchiWhite)
-                                                    .padding(.leading, 4)
-                                            }
-                                            .padding(EdgeInsets(top: 5, leading: 8, bottom: 5, trailing: 12))
-                                        }
-                                        .padding(.top, 13)
                                     }
-                                    
-                                    Text("따봉멍멈무")
+
+                                    Text(card.backName)
                                         .font(.Dotchi_Name2)
                                         .foregroundStyle(Color.dotchiDeepGreen)
                                         .padding(.bottom, 16)
@@ -476,7 +454,7 @@ struct HomeView: View {
         }
     }
     
-    // 시간 차이를 계산하는 함수
+    // 시간 차이 계산하는 함수
     private func timeAgoSinceDate(_ dateString: String) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
@@ -537,8 +515,6 @@ extension View {
     }
 }
 
-
 #Preview {
     HomeView()
 }
-

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
@@ -15,6 +15,8 @@ struct HomeView: View {
         return dateFormatter.string(from: currentDate)
     }
     
+    @ObservedObject var homeViewModel = HomeViewModel()
+    
     var body: some View {
         NavigationStack {
             ZStack {
@@ -435,6 +437,9 @@ struct HomeView: View {
                 }
                 .navigationBarColor(backgroundColor: .dotchiBlack3)
             }
+        }
+        .onAppear() {
+            homeViewModel.fetchHome()
         }
     }
 }

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
@@ -255,11 +255,15 @@ struct HomeView: View {
                                             Image(.icnNextWhite)
                                         }
                                         
-                                        Text("3분전")
-                                            .font(.Sub)
-                                            .foregroundStyle(Color.dotchiWhite)
-                                            .opacity(0.5)
-                                            .padding(.top, 1)
+                                        ForEach(homeViewModel.homeResult?.result.themes ?? [], id: \.themeId) { theme in
+                                            if theme.themeId == 2 { //행운
+                                                Text("\(timeAgoSinceDate(theme.lastCardCreateAt))")
+                                                    .font(.Sub)
+                                                    .foregroundStyle(Color.dotchiWhite)
+                                                    .opacity(0.5)
+                                                    .padding(.top, 1)
+                                            }
+                                        }
                                     }
                                     .padding(.bottom, 15)
                                     .padding(.leading, -10)
@@ -300,11 +304,15 @@ struct HomeView: View {
                                             Image(.icnNextWhite)
                                         }
                                         
-                                        Text("3분전")
-                                            .font(.Sub)
-                                            .foregroundStyle(Color.dotchiWhite)
-                                            .opacity(0.5)
-                                            .padding(.top, 1)
+                                        ForEach(homeViewModel.homeResult?.result.themes ?? [], id: \.themeId) { theme in
+                                            if theme.themeId == 4 { //애정운
+                                                Text("\(timeAgoSinceDate(theme.lastCardCreateAt))")
+                                                    .font(.Sub)
+                                                    .foregroundStyle(Color.dotchiWhite)
+                                                    .opacity(0.5)
+                                                    .padding(.top, 1)
+                                            }
+                                        }
                                     }
                                     .padding(.bottom, 15)
                                     .padding(.leading, -10)
@@ -350,11 +358,15 @@ struct HomeView: View {
                                             Image(.icnNextWhite)
                                         }
                                         
-                                        Text("3분전")
-                                            .font(.Sub)
-                                            .foregroundStyle(Color.dotchiWhite)
-                                            .opacity(0.5)
-                                            .padding(.top, 1)
+                                        ForEach(homeViewModel.homeResult?.result.themes ?? [], id: \.themeId) { theme in
+                                            if theme.themeId == 1 { //건강운
+                                                Text("\(timeAgoSinceDate(theme.lastCardCreateAt))")
+                                                    .font(.Sub)
+                                                    .foregroundStyle(Color.dotchiWhite)
+                                                    .opacity(0.5)
+                                                    .padding(.top, 1)
+                                            }
+                                        }
                                     }
                                     .padding(.bottom, 15)
                                     .padding(.leading, -10)
@@ -395,11 +407,15 @@ struct HomeView: View {
                                             Image(.icnNextWhite)
                                         }
                                         
-                                        Text("3분전")
-                                            .font(.Sub)
-                                            .foregroundStyle(Color.dotchiWhite)
-                                            .opacity(0.5)
-                                            .padding(.top, 1)
+                                        ForEach(homeViewModel.homeResult?.result.themes ?? [], id: \.themeId) { theme in
+                                            if theme.themeId == 3 { //재물운
+                                                Text("\(timeAgoSinceDate(theme.lastCardCreateAt))")
+                                                    .font(.Sub)
+                                                    .foregroundStyle(Color.dotchiWhite)
+                                                    .opacity(0.5)
+                                                    .padding(.top, 1)
+                                            }
+                                        }
                                     }
                                     .padding(.bottom, 15)
                                     .padding(.leading, -10)
@@ -442,24 +458,47 @@ struct HomeView: View {
             homeViewModel.fetchHome()
         }
     }
+    
+    // 시간 차이를 계산하는 함수
+    private func timeAgoSinceDate(_ dateString: String) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        
+        if let date = dateFormatter.date(from: dateString) {
+            let calendar = Calendar.current
+            let components = calendar.dateComponents([.minute, .hour, .day], from: date, to: Date())
+            
+            if let days = components.day, days > 0 {
+                return "\(days)일전"
+            } else if let hours = components.hour, hours > 0 {
+                return "\(hours)시간전"
+            } else if let minutes = components.minute, minutes > 0 {
+                return "\(minutes)분전"
+            } else {
+                return "방금전"
+            }
+        }
+        
+        return ""
+    }
 }
 
 // 네비게이션바 배경색 변경
 struct NavigationBarModifier: ViewModifier {
-
+    
     var backgroundColor: UIColor?
-
+    
     init(backgroundColor: UIColor?) {
         self.backgroundColor = backgroundColor
         let coloredAppearance = UINavigationBarAppearance()
         coloredAppearance.configureWithTransparentBackground()
         coloredAppearance.backgroundColor = backgroundColor
-
+        
         UINavigationBar.appearance().standardAppearance = coloredAppearance
         UINavigationBar.appearance().compactAppearance = coloredAppearance
         UINavigationBar.appearance().scrollEdgeAppearance = coloredAppearance
     }
-
+    
     func body(content: Content) -> some View {
         ZStack{
             content

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
@@ -55,6 +55,7 @@ struct HomeView: View {
                                     
                                     ForEach([secondToday], id: \.cardId) { today in
                                         AsyncImageView(url: URL(string: today.cardImageUrl ?? ""))
+                                            .scaledToFill()
                                             .frame(width: 82, height: 82)
                                             .cornerRadius(25)
                                             .padding(.bottom, 8)
@@ -85,6 +86,7 @@ struct HomeView: View {
                                     ForEach([firstToday], id: \.cardId) { today in
                                         ZStack(alignment: .top) {
                                             AsyncImageView(url: URL(string: today.cardImageUrl ?? ""))
+                                                .scaledToFill()
                                                 .cornerRadius(30)
                                                 .frame(width: 112, height: 112)
                                                 .padding(.bottom, 8)
@@ -124,6 +126,7 @@ struct HomeView: View {
                                     
                                     ForEach([thirdToday], id: \.cardId) { today in
                                         AsyncImageView(url: URL(string: today.cardImageUrl ?? ""))
+                                            .scaledToFill()
                                             .frame(width: 82, height: 82)
                                             .cornerRadius(25)
                                             .padding(.bottom, 8)
@@ -190,6 +193,7 @@ struct HomeView: View {
                                 ZStack(alignment: .bottom) {
                                     ZStack(alignment: .top) {
                                         AsyncImageView(url: URL(string: card.cardImageUrl ?? ""))
+                                            .scaledToFill()
                                             .frame(width: 143, height: 211)
                                             .cornerRadius(8.46)
 

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
@@ -50,84 +50,101 @@ struct HomeView: View {
                         
                         HStack(alignment: .bottom) {
                             VStack {
-                                Image(.imgDefaultDummy)
-                                    .frame(width: 82, height: 82)
-                                    .cornerRadius(25)
-                                    .padding(.bottom, 8)
-                                
-                                ZStack {
-                                    RoundedRectangle(cornerRadius: 67)
-                                        .fill(Color.dotchiLBlack)
-                                        .frame(width: 60, height: 32)
+                                if let todayCards = homeViewModel.homeResult?.result.todayCards, todayCards.count > 1 {
+                                    let secondToday = todayCards[1]
                                     
-                                    Text("이름")
-                                        .font(.Sub)
-                                        .foregroundStyle(Color.dotchiWhite)
+                                    ForEach([secondToday], id: \.cardId) { today in
+                                        AsyncImageView(url: URL(string: today.cardImageUrl ?? ""))
+                                            .frame(width: 82, height: 82)
+                                            .cornerRadius(25)
+                                            .padding(.bottom, 8)
+                                        
+                                        ZStack {
+                                            RoundedRectangle(cornerRadius: 67)
+                                                .fill(Color.dotchiLBlack)
+                                                .frame(width: 110, height: 32)
+                                            
+                                            Text(today.backName)
+                                                .font(.Sub)
+                                                .foregroundStyle(Color.dotchiWhite)
+                                        }
+                                        .padding(EdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5))
+                                        
+                                        Text("2위")
+                                            .font(.Sub_Sbold)
+                                            .foregroundStyle(Color.dotchiGray)
+                                            .padding(.top, 3)
+                                    }
                                 }
-                                .padding(EdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5))
-                                
-                                Text("2위")
-                                    .font(.Sub_Sbold)
-                                    .foregroundStyle(Color.dotchiGray)
-                                    .padding(.top, 3)
                             }
                             
                             VStack {
-                                ZStack(alignment: .top) {
-                                    Image(.imgDefaultDummy)
-                                        .resizable()
-                                        .cornerRadius(30)
-                                        .frame(width: 112, height: 112)
-                                        .padding(.bottom, 8)
+                                if let todayCards = homeViewModel.homeResult?.result.todayCards, todayCards.count > 1 {
+                                    let firstToday = todayCards[0]
                                     
-                                    RoundedRectangle(cornerRadius: 30)
-                                        .stroke(Color.dotchiGreen, lineWidth: 2)
-                                        .frame(width: 112, height: 112)
-                                    
-                                    Image(.icnPlus)
-                                        .resizable()
-                                        .frame(width: 64, height: 64)
-                                        .offset(y: -30)
+                                    ForEach([firstToday], id: \.cardId) { today in
+                                        ZStack(alignment: .top) {
+                                            AsyncImageView(url: URL(string: today.cardImageUrl ?? ""))
+                                                .cornerRadius(30)
+                                                .frame(width: 112, height: 112)
+                                                .padding(.bottom, 8)
+                                            
+                                            RoundedRectangle(cornerRadius: 30)
+                                                .stroke(Color.dotchiGreen, lineWidth: 2)
+                                                .frame(width: 112, height: 112)
+                                            
+                                            Image(.icnPlus)
+                                                .resizable()
+                                                .frame(width: 64, height: 64)
+                                                .offset(y: -30)
+                                        }
+                                        
+                                        ZStack {
+                                            RoundedRectangle(cornerRadius: 67)
+                                                .fill(Color.dotchiLBlack)
+                                                .frame(width: 110, height: 32)
+                                            
+                                            Text(today.backName)
+                                                .font(.Sub)
+                                                .foregroundStyle(Color.dotchiWhite)
+                                        }
+                                        .padding(EdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5))
+                                        
+                                        Text("1위")
+                                            .font(.Sub_Sbold)
+                                            .foregroundStyle(Color.dotchiWhite)
+                                            .padding(.top, 3)
+                                    }
                                 }
-                                
-                                ZStack {
-                                    RoundedRectangle(cornerRadius: 67)
-                                        .fill(Color.dotchiLBlack)
-                                        .frame(width: 60, height: 32)
-                                    
-                                    Text("이름")
-                                        .font(.Sub)
-                                        .foregroundStyle(Color.dotchiWhite)
-                                }
-                                .padding(EdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5))
-                                
-                                Text("1위")
-                                    .font(.Sub_Sbold)
-                                    .foregroundStyle(Color.dotchiWhite)
-                                    .padding(.top, 3)
                             }
                             
                             VStack {
-                                Image(.imgDefaultDummy)
-                                    .frame(width: 82, height: 82)
-                                    .cornerRadius(25)
-                                    .padding(.bottom, 8)
-                                
-                                ZStack {
-                                    RoundedRectangle(cornerRadius: 67)
-                                        .fill(Color.dotchiLBlack)
-                                        .frame(width: 60, height: 32)
+                                if let todayCards = homeViewModel.homeResult?.result.todayCards, todayCards.count > 1 {
+                                    let thirdToday = todayCards[2]
                                     
-                                    Text("이름")
-                                        .font(.Sub)
-                                        .foregroundStyle(Color.dotchiWhite)
+                                    ForEach([thirdToday], id: \.cardId) { today in
+                                        AsyncImageView(url: URL(string: today.cardImageUrl ?? ""))
+                                            .frame(width: 82, height: 82)
+                                            .cornerRadius(25)
+                                            .padding(.bottom, 8)
+                                        
+                                        ZStack {
+                                            RoundedRectangle(cornerRadius: 67)
+                                                .fill(Color.dotchiLBlack)
+                                                .frame(width: 110, height: 32)
+                                            
+                                            Text(today.backName)
+                                                .font(.Sub)
+                                                .foregroundStyle(Color.dotchiWhite)
+                                        }
+                                        .padding(EdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5))
+                                        
+                                        Text("3위")
+                                            .font(.Sub_Sbold)
+                                            .foregroundStyle(Color.dotchiGray)
+                                            .padding(.top, 3)
+                                    }
                                 }
-                                .padding(EdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5))
-                                
-                                Text("3위")
-                                    .font(.Sub_Sbold)
-                                    .foregroundStyle(Color.dotchiGray)
-                                    .padding(.top, 3)
                             }
                         }
                         .padding(.top, 30)
@@ -524,3 +541,4 @@ extension View {
 #Preview {
     HomeView()
 }
+


### PR DESCRIPTION
## 작업한 내용
- 홈 API 구현 c7e01e7d44e231dd29ffb08c602f8688cc7ff1a6
- 테마별 따봉도치.zip 해당 테마의 최신 카드 생성시간 연결(themes) d1e69d0600e4cb12f0e5a20d8898d062ee3461f1
- 오늘의 따봉도치 연결(todayCards) 05161062b62b43cf3c21e74560ddf26aaa7f4a20
- 따봉도치 둘러보기 연결(recentCards) 6dc426a2f78a3dbb5b4be6d4b60a17075c9a5ab3

## 🎶 PR Point
- 홈 화면에서의 보여지는 값들은 연결했고, 화면 이동이 필요한 부분은 다음 이슈에서 한번에 연결하겠습니다..!
- 오늘의 따봉도치가 3위까지 값이 다 안 들어오는 경우 지금 빌드 과정에서 에러가 뜨는데 이 부분 일단은 댓글 3개의 카드에 달아서 해결하고, 다른 부분부터 완성후 추후 보여지는 순위까지만 나타내는 걸로 변경하겠습니다.

## 📸 스크린샷
https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/5844058c-7bde-4b57-b1d6-ab69ad1e939e

## 관련 이슈
- Resolved: #58
