### PR TITLE
[FEAT] 행운별 모아보기 API 연동 

### DIFF
--- a/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
+++ b/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		10FD9EB82B87A50900288506 /* HomeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EB72B87A50900288506 /* HomeResponseDTO.swift */; };
 		10FD9EBA2B87A59400288506 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EB92B87A59400288506 /* HomeService.swift */; };
 		10FD9EBC2B8868B300288506 /* AsyncImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EBB2B8868B300288506 /* AsyncImageView.swift */; };
+		10FD9EBE2B889D1100288506 /* ThemeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EBD2B889D1100288506 /* ThemeResponseDTO.swift */; };
 		FF018E802B75321B006D5627 /* DotchiCircleUIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E7F2B75321B006D5627 /* DotchiCircleUIButton.swift */; };
 		FF018E942B77F2E6006D5627 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E932B77F2E6006D5627 /* UIFont+.swift */; };
 		FF018E9B2B77F95F006D5627 /* BrowseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E9A2B77F95F006D5627 /* BrowseViewController.swift */; };
@@ -140,6 +141,7 @@
 		10FD9EB72B87A50900288506 /* HomeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeResponseDTO.swift; sourceTree = "<group>"; };
 		10FD9EB92B87A59400288506 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
 		10FD9EBB2B8868B300288506 /* AsyncImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImageView.swift; sourceTree = "<group>"; };
+		10FD9EBD2B889D1100288506 /* ThemeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeResponseDTO.swift; sourceTree = "<group>"; };
 		FF018E7F2B75321B006D5627 /* DotchiCircleUIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotchiCircleUIButton.swift; sourceTree = "<group>"; };
 		FF018E922B77F243006D5627 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		FF018E932B77F2E6006D5627 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 			isa = PBXGroup;
 			children = (
 				10FD9EB72B87A50900288506 /* HomeResponseDTO.swift */,
+				10FD9EBD2B889D1100288506 /* ThemeResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -818,6 +821,7 @@
 				FFD594312B7101E1003F1F3C /* SocialLoginRequestDTO.swift in Sources */,
 				FF0CF0AD2B870D4000B9DFC1 /* CardService.swift in Sources */,
 				FFD5942A2B7101A2003F1F3C /* NetworkResult.swift in Sources */,
+				10FD9EBE2B889D1100288506 /* ThemeResponseDTO.swift in Sources */,
 				FF8322812B7BD2190069D68A /* DotchiSortUIButton.swift in Sources */,
 				FF018E9B2B77F95F006D5627 /* BrowseViewController.swift in Sources */,
 				FF4F9C132B860B2900E3DE31 /* CommentsEntity.swift in Sources */,

--- a/DOTCHI/DOTCHI/Global/Enums/LuckyType.swift
+++ b/DOTCHI/DOTCHI/Global/Enums/LuckyType.swift
@@ -71,6 +71,21 @@ extension LuckyType {
         }
     }
     
+    func colorFont() -> Color {
+        switch self {
+        case .health:
+            return Color.dotchiDeepOrange
+        case .lucky:
+            return Color.dotchiDeepGreen
+        case .money:
+            return Color.dotchiDeepBlue
+        case .love:
+            return Color.dotchiDeepPink
+        default:
+            return Color.dotchiWhite
+        }
+    }
+    
     func uiColorNormal() -> UIColor {
         switch self {
         case .health:
@@ -120,6 +135,19 @@ extension LuckyType {
             return "imgMoney"
         case .love:
             return "imgLove"
+        }
+    }
+    
+    func imageNameFront() -> String {
+        switch self {
+        case .health:
+            return "imgHealthFront"
+        case .lucky:
+            return "imgLuckyFront"
+        case .money:
+            return "imgMoneyFront"
+        case .love:
+            return "imgLoveFront"
         }
     }
 }

--- a/DOTCHI/DOTCHI/Networks/DTO/Home/Response/ThemeResponseDTO.swift
+++ b/DOTCHI/DOTCHI/Networks/DTO/Home/Response/ThemeResponseDTO.swift
@@ -1,0 +1,37 @@
+//
+//  ThemeResponseDTO.swift
+//  DOTCHI
+//
+//  Created by yubin on 2/23/24.
+//
+
+import Foundation
+
+struct ThemeResponseDTO: Codable {
+    let code: Int
+    let message: String
+    let result: CardResultDTO
+}
+
+struct CardResultDTO: Codable {
+    let cards: [Card]
+}
+
+struct Card: Codable, Identifiable {
+    let cardId: Int
+    let memberId: Int
+    let memberName: String
+    let memberImageUrl: String
+    let cardImageUrl: String
+    let themeId: Int
+    let backName: String
+    let commentCount: Int
+    
+    var id: Int {
+        return cardId
+    }
+    
+    var themeType: LuckyType {
+        return getLuckyType(forThemeId: themeId)
+    }
+}

--- a/DOTCHI/DOTCHI/Networks/Routers/HomeRouter.swift
+++ b/DOTCHI/DOTCHI/Networks/Routers/HomeRouter.swift
@@ -10,6 +10,7 @@ import Moya
 
 enum HomeRouter {
     case getMain
+    case getTheme(themeId: Int, cardSortType: String, lastCardId: Int, lastCardCommentCount: Int)
 }
 
 extension HomeRouter: TargetType {
@@ -21,13 +22,15 @@ extension HomeRouter: TargetType {
     var path: String {
         switch self {
         case .getMain:
-            return "cards/main"
+            return "/cards/main"
+        case .getTheme:
+            return "/cards/theme"
         }
     }
 
     var method: Moya.Method {
         switch self {
-        case .getMain:
+        case .getMain, .getTheme:
             return .get
         }
     }
@@ -36,12 +39,20 @@ extension HomeRouter: TargetType {
         switch self {
         case .getMain:
             return .requestPlain
+        case let .getTheme(themeId, cardSortType, lastCardId, lastCardCommentCount):
+            let parameters: [String: Any] = [
+                "themeId": themeId,
+                "cardSortType": cardSortType,
+                "lastCardId": lastCardId,
+                "lastCardCommentCount": lastCardCommentCount
+            ]
+            return .requestParameters(parameters: parameters, encoding: URLEncoding.default)
         }
     }
 
     var headers: [String: String]? {
         switch self {
-        case .getMain:
+        case .getMain, .getTheme:
             return [
                 "Content-Type": "application/json",
                 "Authorization": "Bearer \(UserInfo.shared.accessToken)",

--- a/DOTCHI/DOTCHI/Networks/Services/HomeService.swift
+++ b/DOTCHI/DOTCHI/Networks/Services/HomeService.swift
@@ -34,6 +34,32 @@ class HomeViewModel: ObservableObject {
     }
 }
 
+class ThemeViewModel: ObservableObject {
+    @Published var themeResult: ThemeResponseDTO?
+    
+    private let provider = DotchiMoyaProvider<HomeRouter>(isLoggingOn: true)
+    
+    func fetchTheme(themeId: Int, cardSortType: String, lastCardId: Int, lastCardCommentCount: Int ) {
+        provider.request(.getTheme(themeId: themeId, cardSortType: cardSortType, lastCardId: lastCardId, lastCardCommentCount: lastCardCommentCount)) { result in
+            switch result {
+            case let .success(response):
+                do {
+                    let mainResponse = try response.map(ThemeResponseDTO.self)
+                    print("Decoded response: \(mainResponse)")
+                    self.themeResult = mainResponse
+                } catch {
+                    print("Error parsing response: \(error)")
+                    self.themeResult = nil
+                }
+                
+            case let .failure(error):
+                print("Network request failed: \(error)")
+                self.themeResult = nil
+            }
+        }
+    }
+}
+
 /*
 internal protocol HomeServiceProtocol {
     func getMain(completion: @escaping (NetworkResult<Any>) -> (Void))

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/CollectionView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/CollectionView.swift
@@ -23,6 +23,8 @@ struct CollectionView: View {
     @Environment(\.presentationMode) var presentationMode
     @State private var selectedButton: String = "최신순"
     
+    var themeId: Int
+    
     var body: some View {
         NavigationStack {
             ZStack {
@@ -30,9 +32,11 @@ struct CollectionView: View {
                 
                 ScrollView(showsIndicators: false) {
                     VStack(alignment: .leading, spacing: 22) {
-                        Text("행운" + "을 빌어주는 따봉도치")
-                            .font(.Title)
-                            .foregroundStyle(Color.dotchiWhite)
+                        if let luckyTypeName = LuckyType(rawValue: themeId)?.name() {
+                            Text("\(luckyTypeName)" + "을 빌어주는 따봉도치")
+                                .font(.Title)
+                                .foregroundStyle(Color.dotchiWhite)
+                        }
                             
                         HStack {
                             Button(action: {
@@ -114,5 +118,5 @@ struct CollectionView: View {
 }
 
 #Preview {
-    CollectionView()
+    CollectionView(themeId: 1)
 }

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
@@ -199,12 +199,12 @@ struct HomeView: View {
                                             .scaledToFill()
                                             .frame(width: 143, height: 211)
                                             .cornerRadius(8.46)
-
+                                        
                                         Image(.imgLuckyFront)
                                             .resizable()
                                             .frame(width: 143, height: 211)
                                     }
-
+                                    
                                     Text(card.backName)
                                         .font(.Dotchi_Name2)
                                         .foregroundStyle(Color.dotchiDeepGreen)
@@ -235,7 +235,7 @@ struct HomeView: View {
                     
                     HStack {
                         HStack {
-                            NavigationLink(destination: CollectionView()) {
+                            NavigationLink(destination: CollectionView(themeId: 2)) {
                                 ZStack(alignment: .bottomTrailing) {
                                     VStack(alignment: .leading) {
                                         HStack {
@@ -284,7 +284,7 @@ struct HomeView: View {
                         }
                         
                         HStack {
-                            NavigationLink(destination: CollectionView()) {
+                            NavigationLink(destination: CollectionView(themeId: 4)) {
                                 ZStack(alignment: .bottomTrailing) {
                                     VStack(alignment: .leading) {
                                         HStack {
@@ -338,7 +338,7 @@ struct HomeView: View {
                     
                     HStack {
                         HStack {
-                            NavigationLink(destination: CollectionView()) {
+                            NavigationLink(destination: CollectionView(themeId: 1)) {
                                 ZStack(alignment: .bottomTrailing) {
                                     VStack(alignment: .leading) {
                                         HStack {
@@ -387,7 +387,7 @@ struct HomeView: View {
                         }
                         
                         HStack {
-                            NavigationLink(destination: CollectionView()) {
+                            NavigationLink(destination: CollectionView(themeId: 3)) {
                                 ZStack(alignment: .bottomTrailing) {
                                     VStack(alignment: .leading) {
                                         HStack {


### PR DESCRIPTION
## 작업한 내용
- 행운별 모아보기 API 구현
- 테마별 카드 최신순/인기순 조회

## 🎶 PR Point
- 페이징 처리는 미구현 상태입니다..!

## 📸 스크린샷
https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/1adb3a32-2ea6-47bd-aaaa-43662c1a33db

## 관련 이슈
- Resolved: #61 
