### PR TITLE
[FEAT] 마이페이지 조회 API 연동

### DIFF
--- a/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
+++ b/DOTCHI/DOTCHI.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		10FD9EBA2B87A59400288506 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EB92B87A59400288506 /* HomeService.swift */; };
 		10FD9EBC2B8868B300288506 /* AsyncImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EBB2B8868B300288506 /* AsyncImageView.swift */; };
 		10FD9EBE2B889D1100288506 /* ThemeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EBD2B889D1100288506 /* ThemeResponseDTO.swift */; };
+		10FD9EC02B88C24700288506 /* MyRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EBF2B88C24700288506 /* MyRouter.swift */; };
+		10FD9EC22B88C3E000288506 /* MyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EC12B88C3E000288506 /* MyService.swift */; };
+		10FD9EC62B88C46800288506 /* MyResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FD9EC52B88C46800288506 /* MyResponseDTO.swift */; };
 		FF018E802B75321B006D5627 /* DotchiCircleUIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E7F2B75321B006D5627 /* DotchiCircleUIButton.swift */; };
 		FF018E942B77F2E6006D5627 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E932B77F2E6006D5627 /* UIFont+.swift */; };
 		FF018E9B2B77F95F006D5627 /* BrowseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF018E9A2B77F95F006D5627 /* BrowseViewController.swift */; };
@@ -142,6 +145,9 @@
 		10FD9EB92B87A59400288506 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
 		10FD9EBB2B8868B300288506 /* AsyncImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImageView.swift; sourceTree = "<group>"; };
 		10FD9EBD2B889D1100288506 /* ThemeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeResponseDTO.swift; sourceTree = "<group>"; };
+		10FD9EBF2B88C24700288506 /* MyRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRouter.swift; sourceTree = "<group>"; };
+		10FD9EC12B88C3E000288506 /* MyService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyService.swift; sourceTree = "<group>"; };
+		10FD9EC52B88C46800288506 /* MyResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyResponseDTO.swift; sourceTree = "<group>"; };
 		FF018E7F2B75321B006D5627 /* DotchiCircleUIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DotchiCircleUIButton.swift; sourceTree = "<group>"; };
 		FF018E922B77F243006D5627 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		FF018E932B77F2E6006D5627 /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
@@ -261,6 +267,22 @@
 			children = (
 				10FD9EB72B87A50900288506 /* HomeResponseDTO.swift */,
 				10FD9EBD2B889D1100288506 /* ThemeResponseDTO.swift */,
+			);
+			path = Response;
+			sourceTree = "<group>";
+		};
+		10FD9EC32B88C44E00288506 /* My */ = {
+			isa = PBXGroup;
+			children = (
+				10FD9EC42B88C45D00288506 /* Response */,
+			);
+			path = My;
+			sourceTree = "<group>";
+		};
+		10FD9EC42B88C45D00288506 /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				10FD9EC52B88C46800288506 /* MyResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -488,6 +510,7 @@
 		FFD594192B70FF47003F1F3C /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				10FD9EC32B88C44E00288506 /* My */,
 				10FD9EB52B87A4D900288506 /* Home */,
 				FF0CF0A62B8707E200B9DFC1 /* Card */,
 				FFD5942B2B7101B0003F1F3C /* Auth */,
@@ -513,6 +536,7 @@
 				FFD594212B710147003F1F3C /* AuthService.swift */,
 				FF0CF0AC2B870D4000B9DFC1 /* CardService.swift */,
 				10FD9EB92B87A59400288506 /* HomeService.swift */,
+				10FD9EC12B88C3E000288506 /* MyService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -523,6 +547,7 @@
 				FFD5941D2B70FF66003F1F3C /* AuthRouter.swift */,
 				FF0CF0A42B87076F00B9DFC1 /* CardRouter.swift */,
 				10FD9EB32B87A3AD00288506 /* HomeRouter.swift */,
+				10FD9EBF2B88C24700288506 /* MyRouter.swift */,
 			);
 			path = Routers;
 			sourceTree = "<group>";
@@ -792,6 +817,7 @@
 				FFD5944F2B710475003F1F3C /* UIViewcontroller+.swift in Sources */,
 				100A1E2E2B71576B00AAC1E8 /* UploadView.swift in Sources */,
 				10BC6B5A2B86ABA0007D1D9A /* ProfileEditView.swift in Sources */,
+				10FD9EC02B88C24700288506 /* MyRouter.swift in Sources */,
 				FFD306A22B809960004B5AEA /* MakeDotchiPhotoViewController.swift in Sources */,
 				FF83228A2B7C59540069D68A /* BrowseUICollectionViewCell.swift in Sources */,
 				FF0CF09A2B86618500B9DFC1 /* SignInViewController.swift in Sources */,
@@ -818,6 +844,7 @@
 				FFD306BA2B83C25D004B5AEA /* UITextField+.swift in Sources */,
 				FF018E9D2B77F9D7006D5627 /* UIView+.swift in Sources */,
 				FF018EA52B7803CE006D5627 /* UIViewControllerToSwiftUI.swift in Sources */,
+				10FD9EC22B88C3E000288506 /* MyService.swift in Sources */,
 				FFD594312B7101E1003F1F3C /* SocialLoginRequestDTO.swift in Sources */,
 				FF0CF0AD2B870D4000B9DFC1 /* CardService.swift in Sources */,
 				FFD5942A2B7101A2003F1F3C /* NetworkResult.swift in Sources */,
@@ -828,6 +855,7 @@
 				FFD306B82B83C15E004B5AEA /* DotchiUITextField.swift in Sources */,
 				FF0CF0952B8659B600B9DFC1 /* CardEntity.swift in Sources */,
 				FF018E802B75321B006D5627 /* DotchiCircleUIButton.swift in Sources */,
+				10FD9EC62B88C46800288506 /* MyResponseDTO.swift in Sources */,
 				FF4F9C112B860A8C00E3DE31 /* UITableView+.swift in Sources */,
 				FFD594242B710166003F1F3C /* APIConstants.swift in Sources */,
 				FFD594182B70FF2A003F1F3C /* Environment.swift in Sources */,

--- a/DOTCHI/DOTCHI/Networks/DTO/Home/Response/HomeResponseDTO.swift
+++ b/DOTCHI/DOTCHI/Networks/DTO/Home/Response/HomeResponseDTO.swift
@@ -25,13 +25,21 @@ struct TodayCardDTO: Codable {
     let backName: String
 }
 
-struct RecentCardDTO: Codable {
+struct RecentCardDTO: Codable, Identifiable {
     let cardId: Int
     let memberId: Int
     let memberName: String
     let cardImageUrl: String
     let themeId: Int
     let backName: String
+    
+    var id: Int {
+        return cardId
+    }
+    
+    var themeType: LuckyType {
+        return getLuckyType(forThemeId: themeId)
+    }
 }
 
 struct HomeThemeDTO: Codable {

--- a/DOTCHI/DOTCHI/Networks/DTO/My/Response/MyResponseDTO.swift
+++ b/DOTCHI/DOTCHI/Networks/DTO/My/Response/MyResponseDTO.swift
@@ -1,0 +1,27 @@
+//
+//  MyResponseDTO.swift
+//  DOTCHI
+//
+//  Created by yubin on 2/23/24.
+//
+
+import Foundation
+
+struct MyResponseDTO: Codable {
+    let code: Int
+    let message: String
+    let result: MyResultDTO
+}
+
+struct MyResultDTO: Codable {
+    let member: MemberDTO
+    let recentCards: [RecentCardDTO]
+}
+
+struct MemberDTO: Codable {
+    let id: Int
+    let memberName: String
+    let memberImageUrl: String
+    let description: String
+    let cardCount: Int
+}

--- a/DOTCHI/DOTCHI/Networks/Routers/MyRouter.swift
+++ b/DOTCHI/DOTCHI/Networks/Routers/MyRouter.swift
@@ -1,0 +1,55 @@
+//
+//  MyRouter.swift
+//  DOTCHI
+//
+//  Created by yubin on 2/23/24.
+//
+
+import Foundation
+import Moya
+
+enum MyRouter {
+    case getMembers(memberId: Int, lastCardId: Int)
+}
+
+extension MyRouter: TargetType {
+
+    var baseURL: URL {
+        return URL(string: APIConstants.baseURL)!
+    }
+
+    var path: String {
+        switch self {
+        case .getMembers(let memberId, _):
+            return "/members/\(memberId)"
+        }
+    }
+
+    var method: Moya.Method {
+        switch self {
+        case .getMembers:
+            return .get
+        }
+    }
+
+    var task: Task {
+        switch self {
+        case .getMembers(_, let lastCardId):
+            let parameters: [String: Any] = [
+                "lastCardId": lastCardId
+            ]
+            return .requestParameters(parameters: parameters, encoding: URLEncoding.default)
+        }
+    }
+
+    var headers: [String: String]? {
+        switch self {
+        case .getMembers:
+            return [
+                "Content-Type": "application/json",
+                "Authorization": "Bearer \(UserInfo.shared.accessToken)",
+            ]
+        }
+    }
+}
+

--- a/DOTCHI/DOTCHI/Networks/Services/HomeService.swift
+++ b/DOTCHI/DOTCHI/Networks/Services/HomeService.swift
@@ -19,15 +19,12 @@ class HomeViewModel: ObservableObject {
             case let .success(response):
                 do {
                     let mainResponse = try response.map(HomeResponseDTO.self)
-                    print("Decoded response: \(mainResponse)")
                     self.homeResult = mainResponse
                 } catch {
-                    print("Error parsing response: \(error)")
                     self.homeResult = nil
                 }
                 
             case let .failure(error):
-                print("Network request failed: \(error)")
                 self.homeResult = nil
             }
         }
@@ -45,15 +42,12 @@ class ThemeViewModel: ObservableObject {
             case let .success(response):
                 do {
                     let mainResponse = try response.map(ThemeResponseDTO.self)
-                    print("Decoded response: \(mainResponse)")
                     self.themeResult = mainResponse
                 } catch {
-                    print("Error parsing response: \(error)")
                     self.themeResult = nil
                 }
                 
             case let .failure(error):
-                print("Network request failed: \(error)")
                 self.themeResult = nil
             }
         }

--- a/DOTCHI/DOTCHI/Networks/Services/MyService.swift
+++ b/DOTCHI/DOTCHI/Networks/Services/MyService.swift
@@ -1,0 +1,32 @@
+//
+//  MyService.swift
+//  DOTCHI
+//
+//  Created by yubin on 2/23/24.
+//
+
+import Foundation
+import Moya
+
+class MyViewModel: ObservableObject {
+    @Published var myResult: MyResponseDTO?
+    
+    private let provider = DotchiMoyaProvider<MyRouter>(isLoggingOn: true)
+    
+    func fetchMy(memberId: Int, lastCardId: Int) {
+        provider.request(.getMembers(memberId: memberId, lastCardId: lastCardId)) { result in
+            switch result {
+            case let .success(response):
+                do {
+                    let mainResponse = try response.map(MyResponseDTO.self)
+                    self.myResult = mainResponse
+                } catch {
+                    self.myResult = nil
+                }
+                
+            case let .failure(error):
+                self.myResult = nil
+            }
+        }
+    }
+}

--- a/DOTCHI/DOTCHI/Resources/Colorsets.xcassets/dotchiGray2.colorset/Contents.json
+++ b/DOTCHI/DOTCHI/Resources/Colorsets.xcassets/dotchiGray2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x5C",
+          "green" : "0x5C",
+          "red" : "0x5C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
@@ -10,22 +10,25 @@ import SwiftUI
 struct MyView: View {
     @State private var isProfileEditViewPresented = false
     
+    @ObservedObject var myViewModel = MyViewModel()
+    
     var body: some View {
         NavigationStack {
             ZStack {
                 Color.dotchiBlack.ignoresSafeArea()
                 
                 VStack {
-                    Image(.imgDefaultDummy)
-                        .cornerRadius(24)
+                    AsyncImageView(url: URL(string: myViewModel.myResult?.result.member.memberImageUrl ?? ""))
                         .frame(width: 116, height: 116)
+                        .cornerRadius(24)
+                        .scaledToFill()
                     
-                    Text("닉네임일곱글자")
+                    Text(myViewModel.myResult?.result.member.memberName ?? "")
                         .font(.Body)
                         .foregroundColor(Color.dotchiWhite)
                         .padding(.top, 15)
                     
-                    Text("따봉도치의 소개글을 작성해주세요!")
+                    Text(myViewModel.myResult?.result.member.description ?? "")
                         .font(.Sub_Sbold)
                         .foregroundColor(Color.dotchiLgray)
                         .padding(.top, 10)
@@ -37,66 +40,31 @@ struct MyView: View {
                                 .font(.Head2)
                                 .foregroundStyle(Color.dotchiWhite)
                             
-                            Text("14")
+                            Text(String(myViewModel.myResult?.result.recentCards.count ?? 0) ?? "")
                                 .font(.Head2)
                                 .foregroundStyle(Color.dotchiGreen)
                         }
                         
-                        VStack(spacing: 12) {
-                            ForEach(1...3, id: \.self) { rowIndex in
-                                HStack(alignment: .center, spacing: 12) {
-                                    ForEach(1...2, id: \.self) { colIndex in
-                                        ZStack(alignment: .bottom) {
-                                            ZStack(alignment: .top) {
-                                                Image(.imgDefaultDummy)
-                                                    .resizable()
-                                                    .frame(height: 241)
-                                                    .cornerRadius(9.64)
-                                                
-                                                Image(.imgLuckyFront)
-                                                    .resizable()
-                                                    .frame(height: 241)
-                                                
-                                                ZStack {
-                                                    RoundedRectangle(cornerRadius: 60.25)
-                                                        .fill(Color.dotchiDeepGreen)
-                                                        .frame(width: 51, height: 20)
-                                                    
-                                                    HStack(spacing: 0) {
-                                                        Image(.imgDefaultDummy)
-                                                            .resizable()
-                                                            .scaledToFill()
-                                                            .frame(width: 14, height: 14)
-                                                            .clipShape(Circle())
-                                                        
-                                                        Text("오뜨")
-                                                            .font(.S_Sub)
-                                                            .foregroundStyle(Color.dotchiWhite)
-                                                            .padding(.leading, 4)
-                                                    }
-                                                    .padding(EdgeInsets(top: 5, leading: 8, bottom: 5, trailing: 12))
-                                                }
-                                                .padding(.top, 16)
-                                            }
-                                            
-                                            Text("따봉멍멈무")
-                                                .font(.Dotchi_Name2)
-                                                .foregroundStyle(Color.dotchiDeepGreen)
-                                                .padding(.bottom, 20)
-                                        }
-                                    }
-                                }
-                            }
+                        if let cards = myViewModel.myResult?.result.recentCards, !cards.isEmpty {
+                            MyCardGridView(cards: cards)
+                                .padding(.top, 15)
+                                .padding(.bottom, 30)
+                        } else {
+                            ZeroView()
+                                .background(
+                                    RoundedRectangle(cornerRadius: 24)
+                                        .fill(Color.dotchiMgray)
+                                        .frame(maxWidth: .infinity)
+                                )
                         }
-                        .padding(.top, 24)
-                        .padding(.bottom, 30)
                     }
                     .padding(.horizontal, 30)
                     .padding(.top, 24)
                     .background(
                         RoundedRectangle(cornerRadius: 24)
                             .fill(Color.dotchiMgray)
-                    ).fullScreenCover(isPresented: $isProfileEditViewPresented, content: {
+                    )
+                    .fullScreenCover(isPresented: $isProfileEditViewPresented, content: {
                         ProfileEditView()
                             .transition(.move(edge: .trailing))
                     })
@@ -112,6 +80,89 @@ struct MyView: View {
                 )
                 .navigationBarColor(backgroundColor: .dotchiBlack)
             }
+        }
+        .onAppear() {
+            myViewModel.fetchMy(memberId: UserInfo.shared.userID, lastCardId: 999999)
+        }
+    }
+}
+
+struct ZeroView: View {
+    var body: some View {
+        VStack {
+            Image(.imgNClover)
+                .frame(width: 155.9, height: 132)
+                .padding(.top, 90)
+            
+            Text("아직 베푼 행운이 없어요!")
+                .font(.Head2)
+                .foregroundStyle(Color.dotchiGray2)
+                .padding(.top, 20)
+        }
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 24)
+                .fill(Color.dotchiMgray)
+        )
+    }
+}
+
+struct MyCardGridView: View {
+    let cards: [RecentCardDTO]
+    
+    var body: some View {
+        LazyVGrid(columns: [
+            GridItem(.flexible(), spacing: 12),
+            GridItem(.flexible(), spacing: 12),
+        ], spacing: 12) {
+            ForEach(cards) { card in
+                MyCardView(card: card)
+            }
+        }
+    }
+}
+
+struct MyCardView: View {
+    let card: RecentCardDTO
+    
+    @ObservedObject var myViewModel = MyViewModel()
+    
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            ZStack(alignment: .top) {
+                AsyncImageView(url: URL(string: card.cardImageUrl ?? ""))
+                    .scaledToFill()
+                    .frame(width: 163, height: 241)
+                    .cornerRadius(9.64)
+                
+                Image(getFrontImageName(forThemeId: card.themeId))
+                    .resizable()
+                    .frame(width: 163, height: 241)
+                
+                ZStack {
+                    RoundedRectangle(cornerRadius: 60.25)
+                        .fill(card.themeType.colorFont())
+                        .frame(width: 60, height: 20)
+                    
+                    HStack(spacing: 0) {
+                        AsyncImageView(url: URL(string: myViewModel.myResult?.result.member.memberImageUrl ?? ""))
+                            .scaledToFill()
+                            .frame(width: 14, height: 14)
+                            .clipShape(Circle())
+                        
+                        Text(card.memberName)
+                            .font(.S_Sub)
+                            .foregroundStyle(Color.dotchiWhite)
+                            .padding(.leading, 4)
+                    }
+                }
+                .padding(.top, 16)
+            }
+            
+            Text(card.backName)
+                .font(.Dotchi_Name2)
+                .foregroundStyle(card.themeType.colorFont())
+                .padding(.bottom, 20)
         }
     }
 }


### PR DESCRIPTION
## 작업한 내용
- 마이페이지 조회 API 연동
- 나의 따봉도치 0인 경우 구분

## 🎶 PR Point
- `memberId` 1과 3의 화면입니다.

## 📸 스크린샷
| 마이페이지 | 나의 따봉도치 0 |
| -------- | -------- |
| <img width="333px" alt="마이페이지" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/d2bd1bef-84d4-4d83-bd92-13300bb2e765"> | <img width="333px" alt="마이페이지" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/68f0c914-172b-420d-a057-d9314fad7313"> |

## 관련 이슈
- Resolved: #68
