### PR TITLE
[CHORE] 마이페이지 프로필 이미지 관련 수정

### DIFF
--- a/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
@@ -176,25 +176,6 @@ struct MyCardView: View {
                     Image(getFrontImageName(forThemeId: card.themeId))
                         .resizable()
                         .frame(width: 163, height: 241)
-                    
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 60.25)
-                            .fill(card.themeType.colorFont())
-                            .frame(width: 60, height: 20)
-                        
-                        HStack(spacing: 0) {
-                            AsyncImage(url: URL(string: myViewModel.myResult?.result.member.memberImageUrl ?? ""))
-                                .scaledToFill()
-                                .frame(width: 14, height: 14)
-                                .clipShape(Circle())
-                            
-                            Text(card.memberName)
-                                .font(.S_Sub)
-                                .foregroundStyle(Color.dotchiWhite)
-                                .padding(.leading, 4)
-                        }
-                    }
-                    .padding(.top, 16)
                 }
                 
                 Text(card.backName)

--- a/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
@@ -17,10 +17,42 @@ struct MyView: View {
                 Color.dotchiBlack.ignoresSafeArea()
                 
                 VStack {
-                    AsyncImage(url: URL(string: myViewModel.myResult?.result.member.memberImageUrl ?? ""))
-                        .frame(width: 116, height: 116)
-                        .scaledToFill()
-                        .cornerRadius(24)
+                    AsyncImage(url: URL(string: myViewModel.myResult?.result.member.memberImageUrl ?? "")) { phase in
+                        switch phase {
+                        case .empty:
+                            Image(.imgDefaultDummy)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 116, height: 116)
+                                .cornerRadius(24)
+                                .aspectRatio(contentMode: .fill)
+                                .clipped()
+                        case .success(let image):
+                            image
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 116, height: 116)
+                                .cornerRadius(24)
+                                .aspectRatio(contentMode: .fill)
+                                .clipped()
+                        case .failure:
+                            Image(.imgDefaultDummy)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 116, height: 116)
+                                .cornerRadius(24)
+                                .aspectRatio(contentMode: .fill)
+                                .clipped()
+                        @unknown default:
+                            Image(.imgDefaultDummy)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 116, height: 116)
+                                .cornerRadius(24)
+                                .aspectRatio(contentMode: .fill)
+                                .clipped()
+                        }
+                    }
                     
                     Text(myViewModel.myResult?.result.member.memberName ?? "")
                         .font(.Body)

--- a/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
@@ -17,9 +17,9 @@ struct MyView: View {
                 Color.dotchiBlack.ignoresSafeArea()
                 
                 VStack {
-                    AsyncImageView(url: URL(string: myViewModel.myResult?.result.member.memberImageUrl ?? ""))
-                        .scaledToFill()
+                    AsyncImage(url: URL(string: myViewModel.myResult?.result.member.memberImageUrl ?? ""))
                         .frame(width: 116, height: 116)
+                        .scaledToFill()
                         .cornerRadius(24)
                     
                     Text(myViewModel.myResult?.result.member.memberName ?? "")
@@ -81,7 +81,7 @@ struct MyView: View {
             }
         }
         .onAppear() {
-            myViewModel.fetchMy(memberId: UserInfo.shared.userID, lastCardId: 999999)
+            myViewModel.fetchMy(memberId: UserInfo.shared.userID, lastCardId: APIConstants.pagingDefaultValue)
         }
     }
 }
@@ -151,7 +151,7 @@ struct MyCardView: View {
                             .frame(width: 60, height: 20)
                         
                         HStack(spacing: 0) {
-                            AsyncImageView(url: URL(string: myViewModel.myResult?.result.member.memberImageUrl ?? ""))
+                            AsyncImage(url: URL(string: myViewModel.myResult?.result.member.memberImageUrl ?? ""))
                                 .scaledToFill()
                                 .frame(width: 14, height: 14)
                                 .clipShape(Circle())

--- a/DOTCHI/DOTCHI/Sources/Screens/My/ProfileEditView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/My/ProfileEditView.swift
@@ -173,7 +173,7 @@ struct ProfileEditView: View {
             .padding(.horizontal, 20)
         }
         .onDisappear() {
-            myViewModel.fetchMy(memberId: UserInfo.shared.userID, lastCardId: 999999)
+            myViewModel.fetchMy(memberId: UserInfo.shared.userID, lastCardId: APIConstants.pagingDefaultValue)
         }
     }
 }


### PR DESCRIPTION
## 작업한 내용
- 마이페이지 memberImage 불러오기 5cc92a9
- 마이페이지 프로필 이미지 크기 맞추기 a2442d6
- 나의 따봉도치 - 프로필 이미지, 닉네임 삭제 c0dd508

## 🎶 PR Point
- 제가 이걸 이전 브랜치에서 작업을 해버렸는데 지금 발견했네요 .. 일단 먼저 머지하고 나머지 작업 다른 브랜치에서 추가하겠습니다 ..

## 📸 스크린샷
| 마이페이지 |
| -------- |
| <img width="333px" alt="마이페이지" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/9fc908be-58f2-48d4-b7ae-2fef3cec5744"> |

## 관련 이슈
- Resolved: #80 
