### PR TITLE
[CHORE] 홈 / 오늘의 따봉도치 데이터 개수에 따른 UI 수정

### DIFF
--- a/DOTCHI/DOTCHI/Resources/Assets.xcassets/imgDefaultDummy.imageset/imgDefaultDummy.svg
+++ b/DOTCHI/DOTCHI/Resources/Assets.xcassets/imgDefaultDummy.imageset/imgDefaultDummy.svg
@@ -1,3 +1,9 @@
-<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="100" height="100" fill="#AFAFAF" style="fill:#AFAFAF;fill:color(display-p3 0.6872 0.6872 0.6872);fill-opacity:1;"/>
+<svg width="82" height="82" viewBox="0 0 82 82" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_1153_10571" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="82" height="82">
+<rect width="82" height="82" rx="25" fill="#1F1F23" style="fill:#1F1F23;fill:color(display-p3 0.1220 0.1220 0.1378);fill-opacity:1;"/>
+</mask>
+<g mask="url(#mask0_1153_10571)">
+<circle cx="40.9999" cy="41.8039" r="49.8431" fill="#101012" style="fill:#101012;fill:color(display-p3 0.0627 0.0627 0.0706);fill-opacity:1;"/>
+<circle cx="40.9999" cy="41.8039" r="49.8431" stroke="white" style="stroke:white;stroke-opacity:1;"/>
+</g>
 </svg>

--- a/DOTCHI/DOTCHI/Resources/Colorsets.xcassets/dotchiBlack5.colorset/Contents.json
+++ b/DOTCHI/DOTCHI/Resources/Colorsets.xcassets/dotchiBlack5.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x12",
+          "green" : "0x10",
+          "red" : "0x10"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/CollectionView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/CollectionView.swift
@@ -121,25 +121,6 @@ struct CardView: View {
                     Image(getFrontImageName(forThemeId: card.themeId))
                         .resizable()
                         .frame(width: 163, height: 241)
-                    
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 60.25)
-                            .fill(card.themeType.colorFont())
-                            .frame(width: 60, height: 20)
-                        
-                        HStack(spacing: 0) {
-                            AsyncImageView(url: URL(string: card.memberImageUrl ?? ""))
-                                .scaledToFill()
-                                .frame(width: 14, height: 14)
-                                .clipShape(Circle())
-                            
-                            Text(card.memberName)
-                                .font(.S_Sub)
-                                .foregroundStyle(Color.dotchiWhite)
-                                .padding(.leading, 4)
-                        }
-                    }
-                    .padding(.top, 16)
                 }
                 
                 Text(card.backName)

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
@@ -42,10 +42,17 @@ struct HomeView: View {
                                 .frame(height: 170)
                             
                             VStack {
-                                Text("가장 많은 행운을\n나눠준 오늘의 따봉도치")
-                                    .font(.Head)
-                                    .foregroundStyle(.dotchiWhite)
-                                    .multilineTextAlignment(.center)
+                                if let todayCards = homeViewModel.homeResult?.result.todayCards, todayCards.count != 0 {
+                                    Text("가장 많은 행운을\n나눠준 오늘의 따봉도치")
+                                        .font(.Head)
+                                        .foregroundStyle(.dotchiWhite)
+                                        .multilineTextAlignment(.center)
+                                } else {
+                                    Text("아직 오늘의\n따봉도치가 없어요 🥹")
+                                        .font(.Head)
+                                        .foregroundStyle(.dotchiWhite)
+                                        .multilineTextAlignment(.center)
+                                }
                                 
                                 HStack {
                                     Image(.icnGraph)
@@ -58,7 +65,7 @@ struct HomeView: View {
                                 .padding(.top, 5)
                                 .padding(.bottom, 17)
                             }
-                            .padding(.top, 50)
+                            .padding(.top, 35)
                         }
                         
                         HStack(alignment: .bottom) {
@@ -75,7 +82,7 @@ struct HomeView: View {
                                                 .scaledToFill()
                                                 .frame(width: 82, height: 82)
                                                 .cornerRadius(25)
-                                                .padding(.bottom, 8)
+                                                .padding(.bottom, 10)
                                         }
                                         .fullScreenCover(isPresented: Binding(
                                             get: { isDetailPresented },
@@ -85,28 +92,49 @@ struct HomeView: View {
                                                 .transition(.move(edge: .trailing))
                                                 .ignoresSafeArea()
                                         }
-                                       
-                                        ZStack {
-                                            RoundedRectangle(cornerRadius: 67)
-                                                .fill(Color.dotchiLBlack)
-                                                .frame(width: 110, height: 32)
-                                            
-                                            Text(today.backName)
-                                                .font(.Sub)
-                                                .foregroundStyle(Color.dotchiWhite)
-                                        }
-                                        .padding(EdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5))
+                                        
+                                        Text(today.backName)
+                                            .font(.Sub)
+                                            .foregroundStyle(Color.dotchiWhite)
+                                            .padding(EdgeInsets(top: 5, leading: 10, bottom: 5, trailing: 10))
+                                            .background(
+                                                RoundedRectangle(cornerRadius: 67)
+                                                    .fill(Color.dotchiLBlack)
+                                                    .frame(height: 30)
+                                            )
                                         
                                         Text("2위")
                                             .font(.Sub_Sbold)
                                             .foregroundStyle(Color.dotchiGray)
-                                            .padding(.top, 3)
+                                            .padding(.top, 5)
                                     }
+                                } else {
+                                    ZStack {
+                                        RoundedRectangle(cornerRadius: 25)
+                                            .fill(Color.dotchiBlack5)
+                                            .frame(width: 82, height: 82)
+                                        
+                                        Image(.imgClover)
+                                            .resizable()
+                                            .frame(width: 38, height: 51)
+                                            .scaledToFit()
+                                    }
+                                    .padding(.bottom, 10)
+                                    
+                                    RoundedRectangle(cornerRadius: 67)
+                                        .fill(Color.dotchiLBlack)
+                                        .frame(width: 82, height: 30)
+                                    
+                                    Text("2위")
+                                        .font(.Sub_Sbold)
+                                        .foregroundStyle(Color.dotchiGray)
+                                        .padding(.top, 5)
                                 }
                             }
+                            .frame(maxWidth: .infinity)
                             
                             VStack {
-                                if let todayCards = homeViewModel.homeResult?.result.todayCards, todayCards.count > 1 {
+                                if let todayCards = homeViewModel.homeResult?.result.todayCards, todayCards.count > 0 {
                                     let firstToday = todayCards[0]
                                     
                                     ForEach([firstToday], id: \.cardId) { today in
@@ -116,10 +144,10 @@ struct HomeView: View {
                                                 isDetailPresented = true
                                             }) {
                                                 AsyncImageView(url: URL(string: today.cardImageUrl ?? ""))
-                                                    .frame(width: 112, height: 112)
                                                     .scaledToFill()
+                                                    .frame(width: 112, height: 112)
                                                     .cornerRadius(30)
-                                                    .padding(.bottom, 8)
+                                                    .padding(.bottom, 10)
                                             }
                                             .fullScreenCover(isPresented: Binding(
                                                 get: { isDetailPresented },
@@ -140,27 +168,58 @@ struct HomeView: View {
                                                 .offset(y: -30)
                                         }
                                         
-                                        ZStack {
-                                            RoundedRectangle(cornerRadius: 67)
-                                                .fill(Color.dotchiLBlack)
-                                                .frame(width: 110, height: 32)
-                                            
-                                            Text(today.backName)
-                                                .font(.Sub)
-                                                .foregroundStyle(Color.dotchiWhite)
-                                        }
-                                        .padding(EdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5))
+                                        Text(today.backName)
+                                            .font(.Sub)
+                                            .foregroundStyle(Color.dotchiWhite)
+                                            .padding(EdgeInsets(top: 5, leading: 10, bottom: 5, trailing: 10))
+                                            .background(
+                                                RoundedRectangle(cornerRadius: 67)
+                                                    .fill(Color.dotchiLBlack)
+                                                    .frame(height: 30)
+                                            )
                                         
                                         Text("1위")
                                             .font(.Sub_Sbold)
                                             .foregroundStyle(Color.dotchiWhite)
-                                            .padding(.top, 3)
+                                            .padding(.top, 5)
                                     }
+                                } else {
+                                    ZStack(alignment: .top) {
+                                        RoundedRectangle(cornerRadius: 25)
+                                            .fill(Color.dotchiBlack5)
+                                            .frame(width: 112, height: 112)
+                                        
+                                        Image(.imgClover)
+                                            .resizable()
+                                            .frame(width: 51, height: 68)
+                                            .scaledToFit()
+                                            .padding(.top, 25)
+                                        
+                                        RoundedRectangle(cornerRadius: 30)
+                                            .stroke(Color.dotchiGreen, lineWidth: 2)
+                                            .frame(width: 112, height: 112)
+                                        
+                                        Image(.icnPlus)
+                                            .resizable()
+                                            .frame(width: 64, height: 64)
+                                            .offset(y: -30)
+                                    }
+                                    .padding(.bottom, 10)
+                                    
+                                    RoundedRectangle(cornerRadius: 67)
+                                        .fill(Color.dotchiLBlack)
+                                        .frame(width: 114, height: 30)
+                                    
+                                    Text("1위")
+                                        .font(.Sub_Sbold)
+                                        .foregroundStyle(Color.dotchiWhite)
+                                        .padding(.top, 5)
                                 }
                             }
+                            .frame(maxWidth: .infinity)
                             
                             VStack {
-                                if let todayCards = homeViewModel.homeResult?.result.todayCards, todayCards.count > 1 {
+                                if let todayCards = homeViewModel.homeResult?.result.todayCards, todayCards.count > 2 {
                                     let thirdToday = todayCards[2]
                                     
                                     ForEach([thirdToday], id: \.cardId) { today in
@@ -172,7 +231,7 @@ struct HomeView: View {
                                                 .scaledToFill()
                                                 .frame(width: 82, height: 82)
                                                 .cornerRadius(25)
-                                                .padding(.bottom, 8)
+                                                .padding(.bottom, 10)
                                         }
                                         .fullScreenCover(isPresented: Binding(
                                             get: { isDetailPresented },
@@ -183,26 +242,48 @@ struct HomeView: View {
                                                 .ignoresSafeArea()
                                         }
                                         
-                                        ZStack {
-                                            RoundedRectangle(cornerRadius: 67)
-                                                .fill(Color.dotchiLBlack)
-                                                .frame(width: 110, height: 32)
-                                            
-                                            Text(today.backName)
-                                                .font(.Sub)
-                                                .foregroundStyle(Color.dotchiWhite)
-                                        }
-                                        .padding(EdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5))
+                                        Text(today.backName)
+                                            .font(.Sub)
+                                            .foregroundStyle(Color.dotchiWhite)
+                                            .padding(EdgeInsets(top: 5, leading: 10, bottom: 5, trailing: 10))
+                                            .background(
+                                                RoundedRectangle(cornerRadius: 67)
+                                                    .fill(Color.dotchiLBlack)
+                                                    .frame(height: 30)
+                                            )
                                         
                                         Text("3위")
                                             .font(.Sub_Sbold)
                                             .foregroundStyle(Color.dotchiGray)
-                                            .padding(.top, 3)
+                                            .padding(.top, 5)
                                     }
+                                } else {
+                                    ZStack {
+                                        RoundedRectangle(cornerRadius: 25)
+                                            .fill(Color.dotchiBlack5)
+                                            .frame(width: 82, height: 82)
+                                        
+                                        Image(.imgClover)
+                                            .resizable()
+                                            .frame(width: 38, height: 51)
+                                            .scaledToFit()
+                                    }
+                                    .padding(.bottom, 10)
+                                    
+                                    RoundedRectangle(cornerRadius: 67)
+                                        .fill(Color.dotchiLBlack)
+                                        .frame(width: 82, height: 30)
+                                    
+                                    Text("3위")
+                                        .font(.Sub_Sbold)
+                                        .foregroundStyle(Color.dotchiGray)
+                                        .padding(.top, 5)
                                 }
                             }
+                            .frame(maxWidth: .infinity)
                         }
-                        .padding(.top, 30)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 26)
                     }
                     .background(
                         Rectangle()
@@ -590,4 +671,3 @@ extension View {
 #Preview {
     HomeView()
 }
-


### PR DESCRIPTION
## 작업한 내용
- 데이터 개수에 따른 UI 수정
  - 1-3위 데이터가 전부(3개) 넘어오지 않을 경우 고려해서 다른 UI 적용
- 따봉네임 글자수에 따라 변하는 배경 넓이
- 따봉네임이 길어져도 1-3위 `오늘의 따봉도치`들 간격 일정

## 🎶 PR Point
- 차단 후 달라지는 데이터 값 + UI 확인했습니다(develop 브랜치 테스트)

## 📸 스크린샷
| 홈 - 데이터3개 | 홈 - 데이터2개 | 데이터 없는 경우 문구 | 
| -------- | -------- | -------- |
| <img width="333px" alt="데이터3개" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/f68fc4a0-c55a-48e3-9aec-540b0a77aef4"> | <img width="333px" alt="데이터2개" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/e7bec0f3-4559-4ff7-9790-a2a013bcb53c"> | <img width="333px" alt="데이터0개" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/45a7a083-e252-4532-903c-9f5cbb77225c"> |

## 관련 이슈
- Resolved: #85 
