### PR TITLE
[CHORE] 홈, 마이페이지 / card dotchi image layout 수정

### DIFF
--- a/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
@@ -331,11 +331,15 @@ struct HomeView: View {
                                     isDetailPresented = true
                                 }) {
                                     ZStack(alignment: .bottom) {
-                                        ZStack(alignment: .top) {
-                                            AsyncImageView(url: URL(string: card.cardImageUrl ?? ""))
-                                                .scaledToFill()
-                                                .frame(width: 143, height: 211)
-                                                .cornerRadius(8.46)
+                                        ZStack(alignment: .center) {
+                                            GeometryReader { geometry in
+                                                AsyncImageView(url: URL(string: card.cardImageUrl ?? ""))
+                                                    .scaledToFill()
+                                                    .frame(width: geometry.size.width * (210.0 / 270.0),
+                                                           height: geometry.size.width * (210.0 / 270.0))
+                                                    .position(x: geometry.size.width * 0.5,
+                                                              y: geometry.size.height * 0.46)
+                                            }
                                             
                                             Image(getFrontImageName(forThemeId: card.themeId))
                                                 .resizable()

--- a/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
@@ -167,11 +167,15 @@ struct MyCardView: View {
             isDetailPresented = true
         }) {
             ZStack(alignment: .bottom) {
-                ZStack(alignment: .top) {
-                    AsyncImageView(url: URL(string: card.cardImageUrl ?? ""))
-                        .scaledToFill()
-                        .frame(width: 163, height: 241)
-                        .cornerRadius(9.64)
+                ZStack(alignment: .center) {
+                    GeometryReader { geometry in
+                        AsyncImageView(url: URL(string: card.cardImageUrl ?? ""))
+                            .scaledToFill()
+                            .frame(width: geometry.size.width * (210.0 / 270.0),
+                                   height: geometry.size.width * (210.0 / 270.0))
+                            .position(x: geometry.size.width * 0.5,
+                                      y: geometry.size.height * 0.46)
+                    }
                     
                     Image(getFrontImageName(forThemeId: card.themeId))
                         .resizable()


### PR DESCRIPTION
## 작업한 내용
- 홈, 마이페이지 / card dotchi image layout 수정
  - 따봉도치 이미지 확대돼서 보이는 문제 해결

## 🎶 PR Point
- 정빈님이 계산해 주신 값들이랑 약간 다르기는 한데 보여지는 건 제대로 보여서 해당 값들로 수정했습니다

## 📸 스크린샷
| 홈 - 변경전 | 홈 - 변경후 |
| -------- | -------- |
| <img width="333px" alt="변경전" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/3ac6cf80-4aa1-4a58-8a37-e21bcdb374d3"> | <img width="333px" alt="변경후" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/aad9d122-391c-442f-b09d-1b25b5a44fb2"> |

| 마이페이지 - 변경전 | 마이페이지 - 변경후 |
| -------- | -------- |
| <img width="333px" alt="변경전" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/582cfb92-9679-4e5b-93ad-f1f71360b298"> | <img width="333px" alt="변경후" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/95f3d6ce-b419-4895-862d-3e5137871525"> |

## 관련 이슈
- Resolved: #92
