### PR TITLE
[CHORE] 여러 이미지 에러 해결

### DIFF
--- a/DOTCHI/DOTCHI/Sources/Screens/Home/CollectionView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/CollectionView.swift
@@ -118,6 +118,7 @@ struct CardView: View {
                             .scaledToFill()
                             .frame(width: geometry.size.width * (210.0 / 270.0),
                                    height: geometry.size.width * (210.0 / 270.0))
+                            .clipped()
                             .position(x: geometry.size.width * 0.5,
                                       y: geometry.size.height * 0.46)
                     }

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/CollectionView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/CollectionView.swift
@@ -113,10 +113,14 @@ struct CardView: View {
         }) {
             ZStack(alignment: .bottom) {
                 ZStack(alignment: .top) {
-                    AsyncImageView(url: URL(string: card.cardImageUrl ?? ""))
-                        .scaledToFill()
-                        .frame(width: 163, height: 241)
-                        .cornerRadius(9.64)
+                    GeometryReader { geometry in
+                        AsyncImageView(url: URL(string: card.cardImageUrl ?? ""))
+                            .scaledToFill()
+                            .frame(width: geometry.size.width * (210.0 / 270.0),
+                                   height: geometry.size.width * (210.0 / 270.0))
+                            .position(x: geometry.size.width * 0.5,
+                                      y: geometry.size.height * 0.46)
+                    }
                     
                     Image(getFrontImageName(forThemeId: card.themeId))
                         .resizable()

--- a/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/Home/HomeView.swift
@@ -337,6 +337,7 @@ struct HomeView: View {
                                                     .scaledToFill()
                                                     .frame(width: geometry.size.width * (210.0 / 270.0),
                                                            height: geometry.size.width * (210.0 / 270.0))
+                                                    .clipped()
                                                     .position(x: geometry.size.width * 0.5,
                                                               y: geometry.size.height * 0.46)
                                             }

--- a/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/My/MyView.swift
@@ -173,6 +173,7 @@ struct MyCardView: View {
                             .scaledToFill()
                             .frame(width: geometry.size.width * (210.0 / 270.0),
                                    height: geometry.size.width * (210.0 / 270.0))
+                            .clipped()
                             .position(x: geometry.size.width * 0.5,
                                       y: geometry.size.height * 0.46)
                     }

--- a/DOTCHI/DOTCHI/Sources/Screens/My/ProfileEditView.swift
+++ b/DOTCHI/DOTCHI/Sources/Screens/My/ProfileEditView.swift
@@ -69,14 +69,21 @@ struct ProfileEditView: View {
                 
                 VStack(alignment: .center, spacing: 0) {
                     ZStack(alignment:.center) {
-                        RoundedRectangle(cornerRadius: 30)
-                            .fill(Color.dotchiMgray)
-                            .frame(width: 132, height: 132)
-                        
-                        Image(.imgClover)
-                            .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(width: 60, height: 80)
+                        if myViewModel.myResult?.result.member.memberImageUrl == nil {
+                            RoundedRectangle(cornerRadius: 30)
+                                .fill(Color.dotchiMgray)
+                                .frame(width: 132, height: 132)
+                            
+                            Image(.imgClover)
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 60, height: 80)
+                        } else {
+                            AsyncImageView(url: URL(string: myViewModel.myResult?.result.member.memberImageUrl ?? ""))
+                                .scaledToFill()
+                                .frame(width: 132, height: 132)
+                                .cornerRadius(30)
+                        }
                         
                         Image(uiImage: self.image)
                             .resizable()


### PR DESCRIPTION
## 작업한 내용
- 프로필 수정하는 화면에서 프로필 이미지 띄워주기
- 테마별 따봉도치.zip / card dotchi image layout 수정
- 이미지 튀어나오는 현상 해결

## 🎶 PR Point
- 이슈가 다르긴 한데 작은 오류들 소소하게 해결했습니다 ,, 따봉도치 이미지 확대돼서 보이는 문제도 수정 안 했던 부분이 있더라고요 ,,

## 📸 스크린샷
 | 프로필 수정하기 | 테마별 따봉도치.zip |
| -------- | -------- |
| <img width="333px" alt="프로필 수정하기" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/9fdd81cf-1a72-401f-8607-380cc8ea8fbb"> | <img width="333px" alt="테마별 따봉도치.zip" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/2e104a23-bc0a-4ccf-b20b-dc180b851631"> | 

| before | after |
| -------- | -------- |
| <img width="333px" alt="before" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/9f6dfc93-3190-48ab-9af0-e1963a51e214"> | <img width="333px" alt="after" src="https://github.com/dnd-side-project/dnd-10th-9-iOS/assets/69234788/3f9a914b-7f38-41d7-8104-cfac4144240c"> |

## 관련 이슈
- Resolved: #84
